### PR TITLE
hotfix1

### DIFF
--- a/school-login/public/css/app-shell.css
+++ b/school-login/public/css/app-shell.css
@@ -137,6 +137,23 @@
   color: #b91c1c;
 }
 
+.app-nav .nav-notification-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  margin-left: 10px;
+  border-radius: 999px;
+  background: #dc2626;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.22);
+}
+
 .nav-trigger {
   text-align: left;
   gap: 10px;

--- a/school-login/public/css/teacher-pages.css
+++ b/school-login/public/css/teacher-pages.css
@@ -153,7 +153,7 @@
   border: 1px solid var(--teacher-border);
   border-radius: 12px;
   padding: 14px;
-  background: #ffffff;
+  background: var(--surface);
   display: grid;
   gap: 10px;
 }
@@ -169,7 +169,7 @@
 .teacher-message-context {
   margin: 0;
   font-size: 14px;
-  color: #374151;
+  color: var(--text);
 }
 
 .teacher-message-bubble {
@@ -179,12 +179,12 @@
 }
 
 .teacher-message-bubble.student {
-  background: #f8fafc;
+  background: rgba(37, 99, 235, 0.08);
   border-left: 3px solid #2563eb;
 }
 
 .teacher-message-bubble.teacher {
-  background: #f0fdf4;
+  background: rgba(5, 150, 105, 0.12);
   border-left: 3px solid #059669;
 }
 
@@ -222,8 +222,8 @@
 }
 
 .teacher-meta-chip-neutral {
-  background: #f3f4f6;
-  color: #475569;
+  background: var(--surface-2);
+  color: var(--text-muted);
 }
 
 .teacher-thread-controls {
@@ -320,7 +320,7 @@
   margin-top: 0;
   padding: 12px 16px 16px;
   border-top: 1px dashed var(--teacher-border);
-  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+  background: linear-gradient(180deg, var(--surface-2) 0%, var(--surface) 100%);
 }
 
 .teacher-thread-body-header {
@@ -341,12 +341,12 @@
 
 .teacher-test-questions-page .teacher-message-bubble.student {
   border-left-width: 4px;
-  background: #f8fbff;
+  background: rgba(37, 99, 235, 0.1);
 }
 
 .teacher-test-questions-page .teacher-message-bubble.teacher {
   border-left-width: 4px;
-  background: #f2fbf6;
+  background: rgba(5, 150, 105, 0.14);
   margin-left: 18px;
 }
 
@@ -356,7 +356,7 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #334155;
+  color: var(--text-muted);
 }
 
 .teacher-test-questions-page .teacher-reply-form {
@@ -364,7 +364,7 @@
   padding: 12px;
   border: 1px solid var(--teacher-border);
   border-radius: 12px;
-  background: #ffffff;
+  background: var(--surface);
 }
 
 .teacher-test-questions-page .teacher-reply-form textarea {

--- a/school-login/public/css/teacher-pages.css
+++ b/school-login/public/css/teacher-pages.css
@@ -196,6 +196,186 @@
   margin-top: 4px;
 }
 
+.teacher-main-header-compact {
+  padding: 12px 16px;
+}
+
+.teacher-main-header-compact h1 {
+  margin: 0;
+  font-size: 1.55rem;
+  line-height: 1.2;
+}
+
+.teacher-main-header-compact .teacher-eyebrow {
+  margin-bottom: 2px;
+}
+
+.teacher-main-header-compact .teacher-muted {
+  margin-top: 2px;
+}
+
+.teacher-thread-overview {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.teacher-meta-chip-neutral {
+  background: #f3f4f6;
+  color: #475569;
+}
+
+.teacher-thread-controls {
+  align-items: flex-end;
+  gap: 10px 12px;
+  padding: 12px;
+}
+
+.teacher-thread-filter-field {
+  display: grid;
+  gap: 6px;
+  flex: 1 1 190px;
+  min-width: 170px;
+}
+
+.teacher-thread-filter-field.is-search {
+  flex: 2 1 320px;
+  min-width: 250px;
+}
+
+.teacher-filter-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--teacher-muted);
+  letter-spacing: 0.02em;
+}
+
+.teacher-thread-filter-stats {
+  margin-top: -4px;
+}
+
+.teacher-thread-filter-stats .teacher-muted {
+  margin: 0;
+  font-size: 13px;
+}
+
+.teacher-thread-card {
+  padding: 0;
+  overflow: hidden;
+  border-radius: 14px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
+}
+
+.teacher-thread-card .teacher-collapsible-summary {
+  padding: 14px 16px;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.teacher-thread-summary-left {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.teacher-thread-summary-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.teacher-thread-summary-title strong {
+  font-size: 16px;
+}
+
+.teacher-thread-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  font-size: 12px;
+  color: var(--teacher-muted);
+}
+
+.teacher-thread-summary-right {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.teacher-meta-chip-status-open {
+  background: #fff7ed;
+  color: #9a3412;
+}
+
+.teacher-meta-chip-status-closed {
+  background: #ecfdf5;
+  color: #166534;
+}
+
+.teacher-test-questions-page .teacher-collapsible-body {
+  margin-top: 0;
+  padding: 12px 16px 16px;
+  border-top: 1px dashed var(--teacher-border);
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+}
+
+.teacher-thread-body-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.teacher-test-questions-page .teacher-message-bubble {
+  padding: 12px 14px;
+  display: grid;
+  gap: 6px;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
+}
+
+.teacher-test-questions-page .teacher-message-bubble.student {
+  border-left-width: 4px;
+  background: #f8fbff;
+}
+
+.teacher-test-questions-page .teacher-message-bubble.teacher {
+  border-left-width: 4px;
+  background: #f2fbf6;
+  margin-left: 18px;
+}
+
+.teacher-message-author {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #334155;
+}
+
+.teacher-test-questions-page .teacher-reply-form {
+  margin-top: 8px;
+  padding: 12px;
+  border: 1px solid var(--teacher-border);
+  border-radius: 12px;
+  background: #ffffff;
+}
+
+.teacher-test-questions-page .teacher-reply-form textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.teacher-filter-empty {
+  margin-top: 2px;
+}
+
 .grade-message-panel {
   margin-top: 10px;
   padding: 12px;
@@ -1127,6 +1307,18 @@
   .app-shell { grid-template-columns: 1fr; }
   .teacher-sidebar { position: relative; top: 0; }
   .teacher-main-header { flex-direction: column; align-items: flex-start; }
+  .teacher-thread-card .teacher-collapsible-summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .teacher-thread-summary-right {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .teacher-thread-body-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
   .teacher-search-form {
     align-items: stretch;
   }
@@ -1134,6 +1326,21 @@
 }
 
 @media (max-width: 900px) {
+  .teacher-thread-controls {
+    padding: 12px;
+  }
+
+  .teacher-thread-filter-field,
+  .teacher-thread-filter-field.is-search {
+    width: 100%;
+    min-width: 0;
+    flex: 1 1 100%;
+  }
+
+  .teacher-test-questions-page .teacher-message-bubble.teacher {
+    margin-left: 0;
+  }
+
   .page-teacher .teacher-search-form .teacher-search-input,
   .page-teacher .teacher-search-form .teacher-search-select {
     width: 100% !important;

--- a/school-login/views/teacher/teacher-add-grade.ejs
+++ b/school-login/views/teacher/teacher-add-grade.ejs
@@ -37,7 +37,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
             <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>

--- a/school-login/views/teacher/teacher-add-student.ejs
+++ b/school-login/views/teacher/teacher-add-student.ejs
@@ -26,7 +26,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a class="is-active" href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
             <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>

--- a/school-login/views/teacher/teacher-class-statistics.ejs
+++ b/school-login/views/teacher/teacher-class-statistics.ejs
@@ -62,7 +62,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
             <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>

--- a/school-login/views/teacher/teacher-create-template.ejs
+++ b/school-login/views/teacher/teacher-create-template.ejs
@@ -29,7 +29,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>

--- a/school-login/views/teacher/teacher-grade-templates.ejs
+++ b/school-login/views/teacher/teacher-grade-templates.ejs
@@ -51,7 +51,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>

--- a/school-login/views/teacher/teacher-grades.ejs
+++ b/school-login/views/teacher/teacher-grades.ejs
@@ -27,7 +27,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="is-active" href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>

--- a/school-login/views/teacher/teacher-special-assessments.ejs
+++ b/school-login/views/teacher/teacher-special-assessments.ejs
@@ -62,7 +62,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a class="is-active" href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
             <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>

--- a/school-login/views/teacher/teacher-student-grades.ejs
+++ b/school-login/views/teacher/teacher-student-grades.ejs
@@ -62,7 +62,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>

--- a/school-login/views/teacher/teacher-students.ejs
+++ b/school-login/views/teacher/teacher-students.ejs
@@ -26,7 +26,7 @@
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a class="is-active" href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
             <a href="/teacher/grade-templates/<%= classData.id %>">Pruefungen</a>

--- a/school-login/views/teacher/teacher-test-questions.ejs
+++ b/school-login/views/teacher/teacher-test-questions.ejs
@@ -25,7 +25,7 @@
             <a href="/teacher/create-class">Klasse erstellen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
             <a href="/teacher/students/<%= classData.id %>">Schueler</a>
-            <a class="is-active <%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests</a>
+            <a class="is-active <%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
             <a href="/teacher/grade-templates/<%= classData.id %>">Pruefungen</a>

--- a/school-login/views/teacher/teacher-test-questions.ejs
+++ b/school-login/views/teacher/teacher-test-questions.ejs
@@ -38,8 +38,8 @@
         </div>
       </aside>
 
-      <section class="teacher-main">
-        <header class="teacher-main-header">
+      <section class="teacher-main teacher-test-questions-page">
+        <header class="teacher-main-header teacher-main-header-compact">
           <div>
             <p class="teacher-eyebrow">Rueckgaben</p>
             <h1>Fragen zu Tests</h1>
@@ -56,7 +56,10 @@
               <p class="teacher-eyebrow">Konversationen</p>
               <h3>Nachrichtenverlauf</h3>
             </div>
-            <div class="teacher-meta-chip"><%= openMessageCount %> offen</div>
+            <div class="teacher-thread-overview">
+              <div class="teacher-meta-chip"><%= openMessageCount %> offen</div>
+              <div class="teacher-meta-chip teacher-meta-chip-neutral"><%= messageThreads.length %> Konversationen</div>
+            </div>
           </div>
 
           <% if (!messageThreads || messageThreads.length === 0) { %>
@@ -65,38 +68,95 @@
               <p>Schuelerfragen zu Rueckgaben erscheinen hier.</p>
             </div>
           <% } else { %>
-            <div class="teacher-list">
+            <form class="teacher-search-form teacher-thread-controls" id="thread-filter-form" role="search" aria-label="Nachrichten filtern" onsubmit="return false;">
+              <div class="teacher-thread-filter-field is-search">
+                <label class="teacher-filter-label" for="thread-search">Suche</label>
+                <input
+                  class="form-input teacher-search-input"
+                  type="search"
+                  id="thread-search"
+                  placeholder="Schueler, E-Mail, Test oder Nachricht suchen"
+                >
+              </div>
+              <div class="teacher-thread-filter-field">
+                <label class="teacher-filter-label" for="thread-status-filter">Status</label>
+                <select class="form-select teacher-search-select" id="thread-status-filter" aria-label="Statusfilter">
+                  <option value="all">Alle</option>
+                  <option value="open">Nur offen</option>
+                  <option value="closed">Nur beantwortet</option>
+                </select>
+              </div>
+              <div class="teacher-thread-filter-field">
+                <label class="teacher-filter-label" for="thread-sort-filter">Sortierung</label>
+                <select class="form-select teacher-search-select" id="thread-sort-filter" aria-label="Sortierung">
+                  <option value="latest_desc">Neueste zuerst</option>
+                  <option value="latest_asc">Aelteste zuerst</option>
+                  <option value="open_first">Offene zuerst</option>
+                  <option value="student_asc">Name A-Z</option>
+                  <option value="student_desc">Name Z-A</option>
+                </select>
+              </div>
+              <button class="btn btn-secondary" type="button" id="thread-filter-reset">Reset</button>
+            </form>
+
+            <div class="teacher-thread-filter-stats" aria-live="polite">
+              <p class="teacher-muted" id="thread-filter-summary"></p>
+            </div>
+
+            <div class="teacher-list" data-thread-list>
               <% messageThreads.forEach(thread => { %>
-                <% const hasOpenMessages = (thread.messages || []).some(message => !message.teacher_reply); %>
-                <div class="teacher-message-item">
+                <% const openMessages = (thread.messages || []).filter(message => !message.teacher_reply).length; %>
+                <% const hasOpenMessages = openMessages > 0; %>
+                <div
+                  class="teacher-message-item teacher-thread-card"
+                  data-thread-item
+                  data-status="<%= hasOpenMessages ? 'open' : 'closed' %>"
+                  data-open-count="<%= openMessages %>"
+                  data-student-name="<%= thread.student_name || '' %>"
+                  data-latest-ts="<%= thread.latest_at ? new Date(thread.latest_at).getTime() : 0 %>"
+                >
                   <details class="teacher-collapsible" <%= hasOpenMessages ? 'open' : '' %>>
                     <summary class="teacher-collapsible-summary">
-                      <div>
-                        <strong><%= thread.student_name %></strong>
-                        <span class="teacher-muted"><%= thread.student_email %></span>
+                      <div class="teacher-thread-summary-left">
+                        <div class="teacher-thread-summary-title">
+                          <strong><%= thread.student_name %></strong>
+                          <span class="teacher-muted"><%= thread.student_email %></span>
+                        </div>
                         <p class="teacher-message-context">
                           Test: <strong><%= thread.test_name || 'Unbekannter Test' %></strong>
                           <% if (thread.grade_value != null) { %>
                             - Note: <strong><%= thread.grade_value %></strong>
                           <% } %>
                         </p>
+                        <div class="teacher-thread-meta">
+                          <span><%= thread.messages.length %> Nachricht<%= thread.messages.length === 1 ? '' : 'en' %></span>
+                          <span>Letzte Aktivitaet: <%= new Date(thread.latest_at).toLocaleString('de-DE') %></span>
+                        </div>
                       </div>
-                      <div class="teacher-meta-chip"><%= hasOpenMessages ? 'offen' : 'geschlossen' %></div>
+                      <div class="teacher-thread-summary-right">
+                        <% if (hasOpenMessages) { %>
+                          <span class="teacher-meta-chip teacher-meta-chip-status-open"><%= openMessages %> offen</span>
+                        <% } else { %>
+                          <span class="teacher-meta-chip teacher-meta-chip-status-closed">beantwortet</span>
+                        <% } %>
+                      </div>
                     </summary>
 
                     <div class="teacher-collapsible-body">
-                      <small class="teacher-muted"><%= new Date(thread.latest_at).toLocaleString('de-DE') %></small>
-                      <div class="teacher-form-actions">
+                      <div class="teacher-thread-body-header">
+                        <small class="teacher-muted">Letzte Aktivitaet: <%= new Date(thread.latest_at).toLocaleString('de-DE') %></small>
                         <a class="btn btn-secondary btn-sm" href="/teacher/student-grades/<%= classData.id %>/<%= thread.student_id %>">Zum Schueler-Detail</a>
                       </div>
                       <% thread.messages.forEach(message => { %>
                         <div class="teacher-message-bubble student">
+                          <p class="teacher-message-author">Schueler</p>
                           <p><%= message.student_message %></p>
                           <small class="teacher-muted"><%= new Date(message.created_at).toLocaleString('de-DE') %></small>
                         </div>
 
                         <% if (message.teacher_reply) { %>
                           <div class="teacher-message-bubble teacher">
+                            <p class="teacher-message-author">Lehrkraft</p>
                             <p><%= message.teacher_reply %></p>
                             <small class="teacher-muted">
                               Beantwortet: <%= message.replied_at ? new Date(message.replied_at).toLocaleString('de-DE') : '-' %>
@@ -118,19 +178,109 @@
                 </div>
               <% }) %>
             </div>
+            <div class="teacher-empty teacher-filter-empty" id="thread-filter-empty" hidden>
+              <h4>Keine Treffer</h4>
+              <p>Mit den aktuellen Such- und Filterwerten wurde keine Anfrage gefunden.</p>
+            </div>
           <% } %>
         </div>
       </section>
     </div>
     <script>
-      document.querySelectorAll('.teacher-collapsible-summary').forEach((summary) => {
-        summary.addEventListener('click', (event) => {
-          event.preventDefault();
-          const details = summary.closest('details');
-          if (!details) return;
-          details.open = !details.open;
+      (function () {
+        const normalize = (value) => String(value || '')
+          .toLocaleLowerCase('de-DE')
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .trim();
+
+        document.querySelectorAll('.teacher-collapsible-summary').forEach((summary) => {
+          summary.addEventListener('click', (event) => {
+            event.preventDefault();
+            const details = summary.closest('details');
+            if (!details) return;
+            details.open = !details.open;
+          });
         });
-      });
+
+        const threadList = document.querySelector('[data-thread-list]');
+        if (!threadList) return;
+
+        const searchInput = document.getElementById('thread-search');
+        const statusFilter = document.getElementById('thread-status-filter');
+        const sortFilter = document.getElementById('thread-sort-filter');
+        const resetButton = document.getElementById('thread-filter-reset');
+        const filterSummary = document.getElementById('thread-filter-summary');
+        const filterEmpty = document.getElementById('thread-filter-empty');
+
+        const threadEntries = Array.from(threadList.querySelectorAll('[data-thread-item]')).map((item, index) => {
+          const parsedLatestTs = Number(item.dataset.latestTs || 0);
+          return {
+            item,
+            index,
+            status: item.dataset.status || 'closed',
+            openCount: Number(item.dataset.openCount || 0),
+            studentName: normalize(item.dataset.studentName || ''),
+            latestTs: Number.isFinite(parsedLatestTs) ? parsedLatestTs : 0,
+            searchText: normalize(item.textContent)
+          };
+        });
+
+        const sorters = {
+          latest_desc: (a, b) => (b.latestTs - a.latestTs) || (a.index - b.index),
+          latest_asc: (a, b) => (a.latestTs - b.latestTs) || (a.index - b.index),
+          open_first: (a, b) => {
+            if (a.status !== b.status) return a.status === 'open' ? -1 : 1;
+            return (b.latestTs - a.latestTs) || (a.index - b.index);
+          },
+          student_asc: (a, b) => a.studentName.localeCompare(b.studentName, 'de', { sensitivity: 'base' }) || (b.latestTs - a.latestTs),
+          student_desc: (a, b) => b.studentName.localeCompare(a.studentName, 'de', { sensitivity: 'base' }) || (b.latestTs - a.latestTs)
+        };
+
+        function applyFilters() {
+          const query = normalize(searchInput?.value || '');
+          const selectedStatus = statusFilter?.value || 'all';
+          const selectedSort = sortFilter?.value || 'latest_desc';
+          const sorter = sorters[selectedSort] || sorters.latest_desc;
+
+          threadEntries.sort(sorter).forEach(({ item }) => threadList.appendChild(item));
+
+          let visibleCount = 0;
+          let visibleOpenCount = 0;
+
+          threadEntries.forEach((entry) => {
+            const statusMatches = selectedStatus === 'all' || entry.status === selectedStatus;
+            const queryMatches = !query || entry.searchText.includes(query);
+            const isVisible = statusMatches && queryMatches;
+            entry.item.hidden = !isVisible;
+
+            if (isVisible) {
+              visibleCount += 1;
+              visibleOpenCount += entry.openCount;
+            }
+          });
+
+          if (filterSummary) {
+            filterSummary.textContent = `${visibleCount} von ${threadEntries.length} Konversationen sichtbar - ${visibleOpenCount} offene Anfrage(n).`;
+          }
+
+          if (filterEmpty) {
+            filterEmpty.hidden = visibleCount !== 0;
+          }
+        }
+
+        searchInput?.addEventListener('input', applyFilters);
+        statusFilter?.addEventListener('change', applyFilters);
+        sortFilter?.addEventListener('change', applyFilters);
+        resetButton?.addEventListener('click', () => {
+          if (searchInput) searchInput.value = '';
+          if (statusFilter) statusFilter.value = 'all';
+          if (sortFilter) sortFilter.value = 'latest_desc';
+          applyFilters();
+        });
+
+        applyFilters();
+      })();
     </script>
 <% } };
 %>

--- a/school-login/views/teacher/teacher-test-questions.ejs
+++ b/school-login/views/teacher/teacher-test-questions.ejs
@@ -115,7 +115,7 @@
                   data-student-name="<%= thread.student_name || '' %>"
                   data-latest-ts="<%= thread.latest_at ? new Date(thread.latest_at).getTime() : 0 %>"
                 >
-                  <details class="teacher-collapsible" <%= hasOpenMessages ? 'open' : '' %>>
+                  <details class="teacher-collapsible">
                     <summary class="teacher-collapsible-summary">
                       <div class="teacher-thread-summary-left">
                         <div class="teacher-thread-summary-title">


### PR DESCRIPTION
•	Redesigned /teacher/test-questions/:classId layout (more compact header, cleaner card view).
•	Added message search/filter features: full-text search, status filter, sorting, and reset.
•	Improved message request presentation (status badges, metadata, clearer bubble structure).
•	Fixed dark mode issue: message/reply cards now use theme variables instead of hardcoded white colors.
•	Added a red count badge (1, 2, 3, ...) to the “Test Questions” sidebar link when open requests exist.
•	Set all message threads to be collapsed by default (including open requests).