### PR TITLE
Db hotfix

### DIFF
--- a/school-login/db.js
+++ b/school-login/db.js
@@ -349,6 +349,16 @@ function createFakeDb() {
         for (let i = teachingAssignments.length - 1; i >= 0; i -= 1) {
           if (teachingAssignments[i].id === Number(id)) teachingAssignments.splice(i, 1);
         }
+      } else if (/DELETE FROM grade_notifications WHERE student_id IN \(SELECT id FROM students WHERE class_id = \?\)/i.test(sql)) {
+        const [classIdParam] = params;
+        const studentIds = new Set(
+          students
+            .filter((entry) => entry.class_id === Number(classIdParam))
+            .map((entry) => Number(entry.id))
+        );
+        for (let i = notifications.length - 1; i >= 0; i -= 1) {
+          if (studentIds.has(Number(notifications[i].student_id))) notifications.splice(i, 1);
+        }
       } else if (/DELETE FROM grade_notifications WHERE student_id = \?/i.test(sql)) {
         const [studentIdParam] = params;
         for (let i = notifications.length - 1; i >= 0; i -= 1) {
@@ -360,6 +370,9 @@ function createFakeDb() {
           if (students[i].id === Number(idParam) && students[i].class_id === Number(classIdParam)) {
             students.splice(i, 1);
           }
+        }
+        for (let i = notifications.length - 1; i >= 0; i -= 1) {
+          if (notifications[i].student_id === Number(idParam)) notifications.splice(i, 1);
         }
         for (let i = grades.length - 1; i >= 0; i -= 1) {
           if (grades[i].student_id === Number(idParam)) grades.splice(i, 1);
@@ -377,8 +390,21 @@ function createFakeDb() {
         }
       } else if (/DELETE FROM students WHERE class_id = \?/i.test(sql)) {
         const [classIdParam] = params;
+        const studentIds = new Set(
+          students
+            .filter((entry) => entry.class_id === Number(classIdParam))
+            .map((entry) => Number(entry.id))
+        );
         for (let i = students.length - 1; i >= 0; i -= 1) {
           if (students[i].class_id === Number(classIdParam)) students.splice(i, 1);
+        }
+        for (let i = notifications.length - 1; i >= 0; i -= 1) {
+          if (studentIds.has(Number(notifications[i].student_id))) notifications.splice(i, 1);
+        }
+        for (let i = grades.length - 1; i >= 0; i -= 1) {
+          if (studentIds.has(Number(grades[i].student_id)) || grades[i].class_id === Number(classIdParam)) {
+            grades.splice(i, 1);
+          }
         }
         for (let i = specialAssessments.length - 1; i >= 0; i -= 1) {
           if (specialAssessments[i].class_id === Number(classIdParam)) specialAssessments.splice(i, 1);
@@ -1847,12 +1873,21 @@ function createFakeDb() {
         const [id] = params;
         const cls = classes.find((c) => c.id === Number(id));
         rows = cls ? [{ ...cls }] : [];
-      } else if (/SELECT id, name, category, weight, .* FROM grade_templates WHERE class_id = \? ORDER BY date, name/i.test(sql)) {
+      } else if (/SELECT id, name, category, weight, .* FROM grade_templates WHERE class_id = \?/i.test(sql) && /ORDER BY date( DESC)?, name/i.test(sql)) {
         const [clsId] = params;
+        const wantsArchived = /archived_at IS NOT NULL/i.test(sql);
+        const wantsActiveOnly = /archived_at IS NULL/i.test(sql) && !wantsArchived;
+        const sortDescending = /ORDER BY date DESC, name/i.test(sql);
         rows = gradeTemplates
           .filter((t) => t.class_id === Number(clsId))
+          .filter((t) => (wantsArchived ? Boolean(t.archived_at) : wantsActiveOnly ? !t.archived_at : true))
           .sort((a, b) => {
-            if (a.date && b.date && a.date !== b.date) return new Date(a.date) - new Date(b.date);
+            if (a.date && b.date && a.date !== b.date) {
+              const delta = new Date(a.date) - new Date(b.date);
+              return sortDescending ? -delta : delta;
+            }
+            if (a.date && !b.date) return sortDescending ? -1 : 1;
+            if (!a.date && b.date) return sortDescending ? 1 : -1;
             return a.name.localeCompare(b.name);
           })
           .map((t) => ({
@@ -2456,6 +2491,9 @@ async function initializeDatabase() {
     )
   `);
   await pool.query(
+    "ALTER TABLE class_subject_teacher ADD COLUMN IF NOT EXISTS school_year_id INTEGER"
+  );
+  await pool.query(
     "CREATE INDEX IF NOT EXISTS class_subject_teacher_teacher_idx ON class_subject_teacher (teacher_id)"
   );
   await pool.query(
@@ -2493,9 +2531,6 @@ async function initializeDatabase() {
       END IF;
     END $$;
   `);
-  await pool.query(
-    "ALTER TABLE class_subject_teacher ADD COLUMN IF NOT EXISTS school_year_id INTEGER"
-  );
   await pool.query(`
     UPDATE class_subject_teacher cst
     SET school_year_id = c.school_year_id
@@ -3059,13 +3094,24 @@ async function initializeDatabase() {
   await pool.query(`
     CREATE TABLE IF NOT EXISTS grade_notifications (
       id SERIAL PRIMARY KEY,
-      student_id INTEGER NOT NULL REFERENCES students(id),
+      student_id INTEGER NOT NULL REFERENCES students(id) ON DELETE CASCADE,
       message TEXT NOT NULL,
       type TEXT NOT NULL DEFAULT 'info',
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       read_at TIMESTAMPTZ
     )
   `);
+  await pool.query(
+    "ALTER TABLE grade_notifications DROP CONSTRAINT IF EXISTS grade_notifications_student_id_fkey"
+  );
+  await pool.query(`
+    ALTER TABLE grade_notifications
+    ADD CONSTRAINT grade_notifications_student_id_fkey
+    FOREIGN KEY (student_id) REFERENCES students(id) ON DELETE CASCADE
+  `);
+  await pool.query(
+    "CREATE INDEX IF NOT EXISTS grade_notifications_student_idx ON grade_notifications (student_id)"
+  );
 
   await pool.query(`
     CREATE TABLE IF NOT EXISTS audit_logs (

--- a/school-login/public/js/student-dashboard.js
+++ b/school-login/public/js/student-dashboard.js
@@ -772,7 +772,7 @@
             ? `<div class="return-actions"><a class="btn small secondary" href="${downloadUrl}">Datei herunterladen</a><small>${attachmentName}</small></div>`
             : "";
         const requestActionHtml = entry.can_message
-          ? `<div class="return-actions"><a class="btn small" href="/student/requests?gradeId=${encodeURIComponent(String(entry.id))}">${stats.totalCount > 0 ? "Anfragen ansehen" : "Anfrage erstellen"}</a></div>`
+          ? `<div class="return-actions"><a class="btn small" href="/student?page=requests&gradeId=${encodeURIComponent(String(entry.id))}">${stats.totalCount > 0 ? "Anfragen ansehen" : "Anfrage erstellen"}</a></div>`
           : "";
         return `
           <div class="return-row">

--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -6,6 +6,7 @@ const { requireAuth, requireRole } = require("../middleware/auth");
 const { createAuditLogMiddleware } = require("../middleware/audit");
 const { getPasswordValidationError } = require("../utils/password");
 const { deriveNameFromEmail } = require("../utils/studentName");
+const { ensureSubjectIdByName } = require("../utils/subjects");
 
 const INITIAL_PASSWORD = process.env.INITIAL_PASSWORD || null;
 

--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -739,6 +739,10 @@ router.post("/classes/:id/delete", async (req, res, next) => {
         csrfToken: req.csrfToken()
       });
     }
+    await runAsync(
+      "DELETE FROM grade_notifications WHERE student_id IN (SELECT id FROM students WHERE class_id = ?)",
+      [classId]
+    );
     await runAsync("DELETE FROM students WHERE class_id = ?", [classId]);
     await runAsync("DELETE FROM classes WHERE id = ?", [classId]);
     res.redirect("/admin/classes");

--- a/school-login/routes/student.js
+++ b/school-login/routes/student.js
@@ -51,7 +51,19 @@ async function loadStudentProfile(email) {
 
 async function loadClassInfo(classId) {
   return getAsync(
-    "SELECT c.id, c.name, c.subject, u.email AS teacher_email FROM classes c LEFT JOIN users u ON c.teacher_id = u.id WHERE c.id = ?",
+    `SELECT c.id, c.name, c.subject,
+            COALESCE((
+              SELECT STRING_AGG(teacher_rows.email, ', ')
+              FROM (
+                SELECT DISTINCT u.email
+                FROM class_subject_teacher cst
+                JOIN users u ON u.id = cst.teacher_id
+                WHERE cst.class_id = c.id AND cst.subject_id = c.subject_id
+                ORDER BY u.email
+              ) AS teacher_rows
+            ), '') AS teacher_email
+     FROM classes c
+     WHERE c.id = ?`,
     [classId]
   );
 }
@@ -75,9 +87,10 @@ function isValidWeightValue(value) {
 async function loadClassAbsenceMode(classId) {
   const row = await getAsync(
     `SELECT gp.absence_mode
-     FROM classes c
-     LEFT JOIN teacher_grading_profiles gp ON gp.teacher_id = c.teacher_id AND gp.is_active = ?
-     WHERE c.id = ?
+     FROM class_subject_teacher cst
+     JOIN classes c ON c.id = cst.class_id
+     LEFT JOIN teacher_grading_profiles gp ON gp.teacher_id = cst.teacher_id AND gp.is_active = ?
+     WHERE c.id = ? AND cst.subject_id = c.subject_id
      ORDER BY gp.created_at ASC, gp.id ASC
      LIMIT 1`,
     [true, classId]
@@ -104,7 +117,14 @@ async function loadStudentGrades(studentId) {
 
 async function loadTemplates(classId) {
   return allAsync(
-    "SELECT id, name, category, weight, date, description FROM grade_templates WHERE class_id = ? ORDER BY date, name",
+    "SELECT id, name, category, weight, date, description FROM grade_templates WHERE class_id = ? AND archived_at IS NULL ORDER BY date, name",
+    [classId]
+  );
+}
+
+async function loadArchivedTemplates(classId) {
+  return allAsync(
+    "SELECT id, name, category, weight, date, description FROM grade_templates WHERE class_id = ? AND archived_at IS NOT NULL ORDER BY date DESC, name",
     [classId]
   );
 }
@@ -326,6 +346,7 @@ router.get("/", async (req, res, next) => {
     }
 
     const { student, classInfo, classAbsenceMode } = context;
+    const activePage = String(req.query.page || "overview").trim().toLowerCase();
     const gradeRows = await loadStudentGrades(student.id);
     const grades = gradeRows.map((row) => mapGradeRow(row, classInfo));
     const subjectSet = new Set(grades.map((grade) => grade.subject));
@@ -334,12 +355,16 @@ router.get("/", async (req, res, next) => {
     const subjects = Array.from(subjectSet).filter(Boolean);
     const averages = computeAverages(grades, { absenceMode: classAbsenceMode });
     const templates = await loadTemplates(student.class_id);
+    const archivedTemplates = await loadArchivedTemplates(student.class_id);
     const gradeByTemplate = new Map(
       gradeRows
         .filter((row) => row.template_id != null)
         .map((row) => [String(row.template_id), row])
     );
     const tasks = templates.map((template) =>
+      mapTaskRow(template, gradeByTemplate.get(String(template.id)), classInfo)
+    );
+    const archivedTasks = archivedTemplates.map((template) =>
       mapTaskRow(template, gradeByTemplate.get(String(template.id)), classInfo)
     );
     const returns = gradeRows
@@ -358,6 +383,7 @@ router.get("/", async (req, res, next) => {
 
     res.render("student-dashboard", {
       email: req.session.user.email,
+      activePage,
       studentProfile,
       subjects,
       tasks,
@@ -368,6 +394,7 @@ router.get("/", async (req, res, next) => {
         grades,
         averages,
         tasks,
+        archivedTasks,
         returns,
         classAverages,
         notifications,
@@ -458,6 +485,30 @@ router.get("/tasks", async (req, res, next) => {
 
     const { student } = context;
     const templates = await loadTemplates(student.class_id);
+    const gradeRows = await loadStudentGrades(student.id);
+    const gradeByTemplate = new Map(
+      gradeRows
+        .filter((row) => row.template_id != null)
+        .map((row) => [String(row.template_id), row])
+    );
+    const tasks = templates.map((template) =>
+      mapTaskRow(template, gradeByTemplate.get(String(template.id)), context.classInfo)
+    );
+    res.json({ tasks });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get("/archive", async (req, res, next) => {
+  try {
+    const context = await getStudentContext(req);
+    if (!context) {
+      return res.status(404).json({ error: "Student nicht gefunden." });
+    }
+
+    const { student } = context;
+    const templates = await loadArchivedTemplates(student.class_id);
     const gradeRows = await loadStudentGrades(student.id);
     const gradeByTemplate = new Map(
       gradeRows

--- a/school-login/routes/teacher.js
+++ b/school-login/routes/teacher.js
@@ -10,6 +10,7 @@ const schoolYearModel = require("../models/schoolYearModel");
 const { requireAuth, requireRole } = require("../middleware/auth");
 const { createAuditLogMiddleware } = require("../middleware/audit");
 const { deriveNameFromEmail } = require("../utils/studentName");
+const { ensureSubjectIdByName } = require("../utils/subjects");
 
 const runAsync = (sql, params = []) =>
   new Promise((resolve, reject) => {
@@ -747,21 +748,6 @@ function renderError(res, req, message, status, backUrl) {
     backUrl,
     csrfToken: req.csrfToken()
   });
-}
-
-async function ensureSubjectIdByName(subjectName) {
-  const normalized = String(subjectName || "").trim();
-  if (!normalized) return null;
-  const existing = await getAsync("SELECT id FROM subjects WHERE LOWER(name) = LOWER(?)", [normalized]);
-  if (existing) return existing.id;
-  try {
-    const result = await runAsync("INSERT INTO subjects (name) VALUES (?)", [normalized]);
-    return result?.lastID || null;
-  } catch (err) {
-    if (!String(err).includes("UNIQUE")) throw err;
-    const row = await getAsync("SELECT id FROM subjects WHERE LOWER(name) = LOWER(?)", [normalized]);
-    return row?.id || null;
-  }
 }
 
 async function getTeacherAssignments(teacherId) {
@@ -3463,13 +3449,18 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
     let saved = 0;
     let updated = 0;
     let duplicates = 0;
+    const classSchoolYearId = Number(classData.school_year_id);
+
+    if (!Number.isFinite(classSchoolYearId)) {
+      throw new Error(`Klasse ${classId} hat kein gueltiges school_year_id.`);
+    }
 
     for (const row of preparedRows) {
       try {
         if (row.existingGradeId) {
           await runAsync(
             `UPDATE grades
-             SET grade = ?, points_achieved = ?, points_max = ?, note = ?, is_absent = ?
+             SET grade = ?, points_achieved = ?, points_max = ?, note = ?, is_absent = ?, school_year_id = ?
              WHERE id = ? AND class_id = ? AND grade_template_id = ?`,
             [
               row.grade,
@@ -3477,6 +3468,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
               row.pointsMax,
               row.note,
               row.isAbsent,
+              classSchoolYearId,
               row.existingGradeId,
               classId,
               template.id
@@ -3485,7 +3477,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
           updated += 1;
         } else {
           await runAsync(
-            "INSERT INTO grades (student_id, class_id, grade_template_id, grade, points_achieved, points_max, note, external_link, is_absent) VALUES (?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO grades (student_id, class_id, grade_template_id, grade, points_achieved, points_max, note, external_link, is_absent, school_year_id) VALUES (?,?,?,?,?,?,?,?,?,?)",
             [
               row.studentId,
               classId,
@@ -3495,7 +3487,8 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
               row.pointsMax,
               row.note,
               null,
-              row.isAbsent
+              row.isAbsent,
+              classSchoolYearId
             ]
           );
           await runAsync("INSERT INTO grade_notifications (student_id, message, type) VALUES (?,?,?)", [

--- a/school-login/routes/teacher.js
+++ b/school-login/routes/teacher.js
@@ -1179,7 +1179,8 @@ async function loadMessageForTeacher(classId, messageId, teacherId) {
      FROM grade_messages gm
      JOIN grades g ON g.id = gm.grade_id
      JOIN classes c ON c.id = g.class_id
-     WHERE gm.id = ? AND c.id = ? AND c.teacher_id = ?`,
+     JOIN class_subject_teacher cst ON cst.class_id = c.id AND cst.subject_id = c.subject_id
+     WHERE gm.id = ? AND c.id = ? AND cst.teacher_id = ?`,
     [messageId, classId, teacherId]
   );
 }
@@ -1516,6 +1517,10 @@ router.post("/delete-class/:id", async (req, res, next) => {
     const classData = await requireClassAccessForTeacher(req, res, classId);
     if (!classData) return;
 
+    await runAsync(
+      "DELETE FROM grade_notifications WHERE student_id IN (SELECT id FROM students WHERE class_id = ?)",
+      [classId]
+    );
     await runAsync("DELETE FROM students WHERE class_id = ?", [classId]);
     await runAsync("DELETE FROM classes WHERE id = ?", [classId]);
     res.redirect("/teacher/classes");
@@ -2093,6 +2098,7 @@ router.post("/delete-student/:classId/:studentId", async (req, res, next) => {
     const classData = await requireClassAccessForTeacher(req, res, classId);
     if (!classData) return;
 
+    await runAsync("DELETE FROM grade_notifications WHERE student_id = ?", [studentId]);
     await runAsync("DELETE FROM students WHERE id = ? AND class_id = ?", [studentId, classId]);
     res.redirect(`/teacher/students/${classId}`);
   } catch (err) {

--- a/school-login/server.js
+++ b/school-login/server.js
@@ -4,7 +4,7 @@ const session = require("express-session");
 const csrf = require("csurf");
 const path = require("path");
 const crypto = require("crypto");
-require('dotenv').config({ override: true });
+require("dotenv").config();
 const { db, verifyPassword, ready, hashPassword, pool, isFakeDb } = require("./db");
 const { requireAuth } = require("./middleware/auth");
 const { detectDevice } = require("./middleware/deviceDetection");

--- a/school-login/utils/subjects.js
+++ b/school-login/utils/subjects.js
@@ -1,0 +1,29 @@
+const { runAsync, getAsync } = require("./dbAsync");
+
+async function ensureSubjectIdByName(subjectName) {
+  const normalized = String(subjectName || "").trim();
+  if (!normalized) return null;
+
+  const existing = await getAsync(
+    "SELECT id FROM subjects WHERE LOWER(name) = LOWER(?)",
+    [normalized]
+  );
+  if (existing) return existing.id;
+
+  try {
+    const result = await runAsync("INSERT INTO subjects (name) VALUES (?)", [normalized]);
+    return result?.lastID || null;
+  } catch (err) {
+    if (!String(err).includes("UNIQUE")) throw err;
+
+    const row = await getAsync(
+      "SELECT id FROM subjects WHERE LOWER(name) = LOWER(?)",
+      [normalized]
+    );
+    return row?.id || null;
+  }
+}
+
+module.exports = {
+  ensureSubjectIdByName
+};

--- a/school-login/views/student-dashboard.ejs
+++ b/school-login/views/student-dashboard.ejs
@@ -7,7 +7,8 @@
     grades: { title: "Schueler - Noten", heading: "Noten" },
     archive: { title: "Schueler - Archiv", heading: "Archiv" }
   };
-  const currentPage = pageMeta[activePage] ? activePage : "overview";
+  const requestedPage = typeof activePage !== "undefined" ? String(activePage) : "overview";
+  const currentPage = pageMeta[requestedPage] ? requestedPage : "overview";
   const currentMeta = pageMeta[currentPage];
   const safeSubjects = Array.isArray(subjects) ? subjects : [];
   const page = {
@@ -34,11 +35,11 @@
           <div class="nav-section">
             <div class="nav-section-title">Menue</div>
             <a class="<%= currentPage === 'overview' ? 'is-active' : '' %>" href="/student">Uebersicht</a>
-            <a class="<%= currentPage === 'tasks' ? 'is-active' : '' %>" href="/student/tasks">Aufgaben</a>
-            <a class="<%= currentPage === 'returns' ? 'is-active' : '' %>" href="/student/returns">Rueckgaben</a>
-            <a class="<%= currentPage === 'requests' ? 'is-active' : '' %>" href="/student/requests">Anfragen</a>
-            <a class="<%= currentPage === 'grades' ? 'is-active' : '' %>" href="/student/grades">Noten</a>
-            <a class="<%= currentPage === 'archive' ? 'is-active' : '' %>" href="/student/archive">Archiv</a>
+            <a class="<%= currentPage === 'tasks' ? 'is-active' : '' %>" href="/student?page=tasks">Aufgaben</a>
+            <a class="<%= currentPage === 'returns' ? 'is-active' : '' %>" href="/student?page=returns">Rueckgaben</a>
+            <a class="<%= currentPage === 'requests' ? 'is-active' : '' %>" href="/student?page=requests">Anfragen</a>
+            <a class="<%= currentPage === 'grades' ? 'is-active' : '' %>" href="/student?page=grades">Noten</a>
+            <a class="<%= currentPage === 'archive' ? 'is-active' : '' %>" href="/student?page=archive">Archiv</a>
             <form class="logout-form" method="POST" action="/logout">
               <% if (typeof csrfToken !== "undefined") { %>
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>">


### PR DESCRIPTION
Added
Added a shared ensureSubjectIdByName helper in utils/subjects.js.
Added a /student/archive API endpoint for archived student tasks.
Added defensive indexing/migration handling for grade_notifications.student_id.
Changed
Refactored admin and teacher class creation/edit flows to use the shared subject helper instead of duplicated logic.
Updated student dashboard page switching to use ?page=... navigation instead of linking sidebar items to JSON endpoints.
Split student task loading into active templates and archived templates.
Changed student/teacher assignment lookups to use class_subject_teacher instead of the removed classes.teacher_id.
Changed environment loading in server.js so explicit process env vars are no longer overwritten by .env.
Fixed
Fixed PostgreSQL startup migration order for class_subject_teacher.school_year_id so legacy data inserts no longer fail on missing columns.
Fixed the EJS activePage is not defined crash in student-dashboard.ejs.
Fixed broken student dashboard navigation for Tasks, Returns, Requests, Grades, and Archive.
Fixed teacher message lookup to work with the new class/subject assignment model.
Fixed grade_notifications.student_id foreign key behavior by enforcing ON DELETE CASCADE.
Fixed admin and teacher delete flows so class/student deletion no longer trips over leftover grade notifications.
Fixed fake DB delete behavior to mirror notification cleanup/cascade behavior more closely.
Fixed the missing ensureSubjectIdByName reference in routes/admin.js.
Fixed bulk grade saving so grades.school_year_id is always written on insert and repaired on update.
Added a guard that fails early if a class has no valid school_year_id before writing grades.
Audit / Consistency Checks
Checked all productive INSERT INTO grades paths; both runtime paths now include school_year_id.
Checked all foreign keys referencing students(id); they now consistently use ON DELETE CASCADE.
Searched the route layer for similar ensure* helper usage; the missing admin helper reference was the only unresolved case.
Confirmed the remaining old INSERT INTO grades statements are in fake-db/test code paths, not in productive PostgreSQL routes.
Tuest smoke tests for admin class creation and teacher bulk grading.