### PR TITLE
fixed admin sidebar

### DIFF
--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -122,6 +122,14 @@ async function getActiveClassById(classId, columns = "id, name") {
 
 router.use(requireAuth, requireRole("admin"));
 router.use(createAuditLogMiddleware());
+router.use(async (req, res, next) => {
+  try {
+    res.locals.activeSchoolYear = await schoolYearModel.getActiveSchoolYear();
+  } catch (err) {
+    res.locals.activeSchoolYear = null;
+  }
+  next();
+});
 
 router.get("/", async (req, res, next) => {
   try {

--- a/school-login/views/admin/nav-school-year.ejs
+++ b/school-login/views/admin/nav-school-year.ejs
@@ -1,9 +1,9 @@
-<% const resolvedActiveSchoolYear = activeSchoolYear || null; %>
+<% const resolvedActiveSchoolYear = (typeof activeSchoolYear !== "undefined" ? activeSchoolYear : locals.activeSchoolYear) || null; %>
 <aside class="app-sidebar" aria-label="Admin Navigation">
   <div class="sidebar-brand">
     <div>
       <div class="sidebar-title">Admin-Konsole</div>
-      <div class="sidebar-meta"><%= currentUser?.email %> · <%= currentUser?.role %></div>
+      <div class="sidebar-meta"><%= currentUser?.email %> &middot; <%= currentUser?.role %></div>
       <% if (resolvedActiveSchoolYear) { %>
         <div class="sidebar-meta">Aktiv: <%= resolvedActiveSchoolYear.name %></div>
       <% } %>

--- a/school-login/views/admin/nav.ejs
+++ b/school-login/views/admin/nav.ejs
@@ -1,39 +1,6 @@
-<aside class="app-sidebar" aria-label="Admin Navigation">
-  <div class="sidebar-brand">
-    <div>
-      <div class="sidebar-title">Admin-Konsole</div>
-      <div class="sidebar-meta"><%= currentUser?.email %> · <%= currentUser?.role %></div>
-    </div>
-    <span class="sidebar-badge">Eingeloggt</span>
-  </div>
-
-  <div class="app-nav">
-    <div class="nav-section">
-      <div class="nav-section-title">Navigation</div>
-      <a class="<%= activePath === '/admin' ? 'is-active' : '' %>" href="/admin">Home</a>
-    </div>
-
-    <div class="nav-section">
-      <div class="nav-section-title">Klassen</div>
-      <a class="<%= activePath.startsWith('/admin/classes') && !activePath.endsWith('/new') ? 'is-active' : '' %>" href="/admin/classes">Übersicht</a>
-      <a class="<%= activePath === '/admin/classes/new' ? 'is-active' : '' %>" href="/admin/classes/new">Klasse erstellen</a>
-      <a class="<%= activePath.startsWith('/admin/assignments') ? 'is-active' : '' %>" href="/admin/assignments">Unterrichtszuordnung</a>
-    </div>
-
-    <div class="nav-section">
-      <div class="nav-section-title">Nutzer</div>
-      <a class="<%= activePath.startsWith('/admin/users') && !activePath.includes('/new') ? 'is-active' : '' %>" href="/admin/users">Nutzerliste</a>
-      <a class="<%= activePath.includes('/users/new') ? 'is-active' : '' %>" href="/admin/users/new">Nutzer anlegen</a>
-    </div>
-
-    <div class="nav-section">
-      <div class="nav-section-title">Logs</div>
-      <a class="<%= activePath.startsWith('/admin/audit-logs') ? 'is-active' : '' %>" href="/admin/audit-logs">Logs</a>
-    </div>
-
-    <form class="logout-form" method="POST" action="/logout">
-      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-      <button type="submit" class="app-nav-link">Logout</button>
-    </form>
-  </div>
-</aside>
+<%- include('./nav-school-year', {
+  csrfToken,
+  currentUser,
+  activePath,
+  activeSchoolYear: (typeof activeSchoolYear !== "undefined" ? activeSchoolYear : locals.activeSchoolYear) || null
+}) %>


### PR DESCRIPTION
Changelog

2026-03-16

Unified the admin sidebar across all admin pages so the left navigation no longer switches to a different layout after clicking a menu item.
Updated [views/admin/nav.ejs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/andre/.vscode/extensions/openai.chatgpt-26.304.20706-win32-x64/webview/) to reuse the shared school-year sidebar instead of maintaining a separate older sidebar version.
Added admin middleware in [routes/admin.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/andre/.vscode/extensions/openai.chatgpt-26.304.20706-win32-x64/webview/) to load activeSchoolYear into res.locals for every admin route.
Updated [views/admin/nav-school-year.ejs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/andre/.vscode/extensions/openai.chatgpt-26.304.20706-win32-x64/webview/) to fall back to the global activeSchoolYear local when it is not passed explicitly.
Fixed sidebar text encoding in [views/admin/nav-school-year.ejs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/andre/.vscode/extensions/openai.chatgpt-26.304.20706-win32-x64/webview/) so the user meta line renders correctly.
Verified the sidebar templates with an EJS render test to ensure the shared navigation still renders without template errors.