### PR TITLE
repaired auditlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /.idea/NVS.iml
 /output/pdf/nvs-app-summary.pdf
 /.idea/vcs.xml
+/.idea/

--- a/school-login/views/admin/nav-school-year.ejs
+++ b/school-login/views/admin/nav-school-year.ejs
@@ -31,6 +31,11 @@
     </div>
 
     <div class="nav-section">
+      <div class="nav-section-title">Logs</div>
+      <a class="<%= activePath.startsWith('/admin/audit-logs') ? 'is-active' : '' %>" href="/admin/audit-logs">Audit-Log</a>
+    </div>
+
+    <div class="nav-section">
       <div class="nav-section-title">Schuljahre</div>
       <a class="<%= activePath.startsWith('/admin/rollover') ? 'is-active' : '' %>" href="/admin/rollover">School Year Management</a>
       <a class="<%= activePath.startsWith('/archive') ? 'is-active' : '' %>" href="/archive">Archiv</a>


### PR DESCRIPTION
## Changelog

- Restored the missing `Audit-Log` entry in the admin sidebar navigation.
- Added a dedicated `Logs` section to the shared admin menu.
- Reconnected the sidebar link to the existing `/admin/audit-logs` route.
- Restored active-state highlighting for the audit log page in the left navigation.
- Applied the fix in the shared admin navigation template so the menu item appears again across admin views.
