### PR TITLE
user creation fix

### DIFF
--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -263,36 +263,6 @@ router.post("/users", async (req, res, next) => {
     }
   }
 
-  if (wantsInitial) {
-    if (!INITIAL_PASSWORD) {
-      return res.status(400).render("error", {
-        message: "Initial-Passwort ist nicht konfiguriert (ENV INITIAL_PASSWORD).",
-        status: 400,
-        backUrl,
-        csrfToken: req.csrfToken()
-      });
-    }
-    const initialError = getPasswordValidationError(INITIAL_PASSWORD);
-    if (initialError) {
-      return res.status(400).render("error", {
-        message: `Initial-Passwort ist zu schwach: ${initialError}`,
-        status: 400,
-        backUrl,
-        csrfToken: req.csrfToken()
-      });
-    }
-  } else {
-    const passwordError = getPasswordValidationError(password);
-    if (passwordError) {
-      return res.status(400).render("error", {
-        message: passwordError,
-        status: 400,
-        backUrl,
-        csrfToken: req.csrfToken()
-      });
-    }
-  }
-
   const chosenPassword = wantsInitial ? INITIAL_PASSWORD : password;
   const mustChange = wantsInitial ? 1 : 0;
   const hash = hashPassword(chosenPassword);


### PR DESCRIPTION
Fixed a server error when creating new users in the admin area. The POST /admin/users route contained a duplicated password-validation block that referenced an undefined backUrl, which caused a 500 Internal Server Error during user creation. The duplicate block was removed, while the existing password and initial-password validation logic was kept intact. As a result, user creation now works again and invalid input returns proper validation errors instead of crashing the server.