### PR TITLE
panels replaced with name from email

### DIFF
--- a/school-login/public/css/app-shell.css
+++ b/school-login/public/css/app-shell.css
@@ -43,10 +43,16 @@
 .sidebar-brand {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 12px;
   padding: 12px 10px 16px;
   border-bottom: 1px solid var(--shell-border);
   margin-bottom: 14px;
+}
+
+.sidebar-brand-copy {
+  flex: 1;
+  min-width: 0;
 }
 
 .sidebar-badge {
@@ -65,6 +71,7 @@
   font-size: 15px;
   font-weight: 800;
   color: var(--shell-text);
+  line-height: 1.35;
 }
 
 .sidebar-meta {

--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -538,13 +538,45 @@ router.post("/users/:id/reset", async (req, res, next) => {
   const wantsInitial = useInitial === "1";
   const backUrl = wantsInitial ? "/admin/users" : `/admin/users/${id}/edit`;
 
-  if (!wantsInitial && !password)
+  if (!wantsInitial && !password) {
     return res.status(400).render("error", {
       message: "Kein Passwort angegeben.",
       status: 400,
       backUrl,
       csrfToken: req.csrfToken()
     });
+  }
+
+  if (wantsInitial) {
+    if (!INITIAL_PASSWORD) {
+      return res.status(400).render("error", {
+        message: "Initial-Passwort ist nicht konfiguriert (ENV INITIAL_PASSWORD).",
+        status: 400,
+        backUrl,
+        csrfToken: req.csrfToken()
+      });
+    }
+
+    const initialError = getPasswordValidationError(INITIAL_PASSWORD);
+    if (initialError) {
+      return res.status(400).render("error", {
+        message: `Initial-Passwort ist zu schwach: ${initialError}`,
+        status: 400,
+        backUrl,
+        csrfToken: req.csrfToken()
+      });
+    }
+  } else {
+    const passwordError = getPasswordValidationError(password);
+    if (passwordError) {
+      return res.status(400).render("error", {
+        message: passwordError,
+        status: 400,
+        backUrl,
+        csrfToken: req.csrfToken()
+      });
+    }
+  }
 
   const chosenPassword = wantsInitial ? INITIAL_PASSWORD : password;
   const mustChange = wantsInitial ? 1 : 0;

--- a/school-login/server.js
+++ b/school-login/server.js
@@ -10,6 +10,7 @@ const { requireAuth } = require("./middleware/auth");
 const { detectDevice } = require("./middleware/deviceDetection");
 const { buildSessionStore } = require("./sessionStore");
 const { getPasswordValidationError } = require("./utils/password");
+const userDisplay = require("./utils/userDisplay");
 
 const adminRouter = require("./routes/admin");
 const assignmentRouter = require("./routes/assignmentRoutes");
@@ -113,6 +114,7 @@ app.use(
 );
 
 app.locals.assetVersion = assetVersion;
+app.locals.userDisplay = userDisplay;
 app.use((req, res, next) => {
   res.locals.assetVersion = assetVersion;
   next();

--- a/school-login/utils/userDisplay.js
+++ b/school-login/utils/userDisplay.js
@@ -1,0 +1,87 @@
+const ROLE_LABELS = Object.freeze({
+  admin: "Administrator",
+  student: "Sch\u00fcler",
+  teacher: "Lehrer"
+});
+
+const SCHOOL_BADGE_LABEL = "HTLWY";
+
+function getEmailLocalPart(email) {
+  const normalizedEmail = String(email || "").trim();
+  if (!normalizedEmail) return "";
+
+  const atIndex = normalizedEmail.indexOf("@");
+  if (atIndex <= 0) return "";
+  return normalizedEmail.slice(0, atIndex).trim();
+}
+
+function capitalizeWord(word) {
+  const normalizedWord = String(word || "").trim();
+  if (!normalizedWord) return "";
+  return normalizedWord.charAt(0).toLocaleUpperCase("de-AT") + normalizedWord.slice(1).toLocaleLowerCase("de-AT");
+}
+
+function formatNameFromEmail(email) {
+  const localPart = getEmailLocalPart(email);
+  if (!/^[a-z]+(?:\.[a-z]+)+$/i.test(localPart)) {
+    return "";
+  }
+
+  return localPart
+    .split(".")
+    .filter(Boolean)
+    .map(capitalizeWord)
+    .join(" ");
+}
+
+function formatReadableIdentifier(value) {
+  const localPart = getEmailLocalPart(value) || String(value || "").trim();
+  if (!localPart) return "";
+
+  return localPart
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean)
+    .map(capitalizeWord)
+    .join(" ");
+}
+
+function getRoleLabel(role) {
+  const normalizedRole = String(role || "").trim().toLowerCase();
+  return ROLE_LABELS[normalizedRole] || "Nutzer";
+}
+
+function getDisplayName({ email, name } = {}) {
+  const nameFromEmail = formatNameFromEmail(email);
+  if (nameFromEmail) return nameFromEmail;
+
+  const fallbackName = String(name || "").trim();
+  if (fallbackName && fallbackName.toLowerCase() !== String(email || "").trim().toLowerCase()) {
+    return fallbackName;
+  }
+
+  const readableIdentifier = formatReadableIdentifier(email);
+  if (readableIdentifier) return readableIdentifier;
+
+  return "Nutzer";
+}
+
+function buildSidebarUser({ email, role, name } = {}) {
+  return {
+    badgeLabel: SCHOOL_BADGE_LABEL,
+    displayName: getDisplayName({ email, name }),
+    roleLabel: getRoleLabel(role)
+  };
+}
+
+module.exports = {
+  ROLE_LABELS,
+  SCHOOL_BADGE_LABEL,
+  buildSidebarUser,
+  formatNameFromEmail,
+  formatReadableIdentifier,
+  getDisplayName,
+  getRoleLabel
+};

--- a/school-login/views/admin/index.ejs
+++ b/school-login/views/admin/index.ejs
@@ -11,13 +11,7 @@
     content: function () { %>
     <div class="app-shell">
       <aside class="app-sidebar" aria-label="Admin Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Admin-Panel</div>
-            <div class="sidebar-meta"><%= currentUser?.email %> · <%= currentUser?.role %></div>
-          </div>
-          
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email: currentUser?.email, role: currentUser?.role, name: currentUser?.name } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/admin/nav-school-year.ejs
+++ b/school-login/views/admin/nav-school-year.ejs
@@ -1,15 +1,5 @@
-<% const resolvedActiveSchoolYear = (typeof activeSchoolYear !== "undefined" ? activeSchoolYear : locals.activeSchoolYear) || null; %>
 <aside class="app-sidebar" aria-label="Admin Navigation">
-  <div class="sidebar-brand">
-    <div>
-      <div class="sidebar-title">Admin-Konsole</div>
-      <div class="sidebar-meta"><%= currentUser?.email %> &middot; <%= currentUser?.role %></div>
-      <% if (resolvedActiveSchoolYear) { %>
-        <div class="sidebar-meta">Aktiv: <%= resolvedActiveSchoolYear.name %></div>
-      <% } %>
-    </div>
-    <span class="sidebar-badge">Eingeloggt</span>
-  </div>
+  <%- include('../partials/sidebar-user-card', { user: { email: currentUser?.email, role: currentUser?.role, name: currentUser?.name } }) %>
 
   <div class="app-nav">
     <div class="nav-section">

--- a/school-login/views/partials/sidebar-user-card.ejs
+++ b/school-login/views/partials/sidebar-user-card.ejs
@@ -1,0 +1,10 @@
+<%
+  const sidebarUser = userDisplay.buildSidebarUser(user || {});
+%>
+<div class="sidebar-brand">
+  <div class="sidebar-brand-copy">
+    <div class="sidebar-title"><%= sidebarUser.displayName %></div>
+    <div class="sidebar-meta"><%= sidebarUser.roleLabel %></div>
+  </div>
+  <span class="sidebar-badge"><%= sidebarUser.badgeLabel %></span>
+</div>

--- a/school-login/views/student-dashboard.ejs
+++ b/school-login/views/student-dashboard.ejs
@@ -23,13 +23,7 @@
     <button class="mobile-nav-toggle" aria-label="Navigation oeffnen"></button>
     <div class="app-shell app-shell-wide">
       <aside class="app-sidebar" aria-label="Schuelernavigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Schueler-Dashboard</div>
-            <div class="sidebar-meta"><%= studentProfile.name %> &middot; <%= studentProfile.class %></div>
-          </div>
-          <span class="sidebar-badge">Aktiv</span>
-        </div>
+        <%- include('./partials/sidebar-user-card', { user: { email, role: 'student', name: studentProfile.name } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-add-grade.ejs
+++ b/school-login/views/teacher/teacher-add-grade.ejs
@@ -21,13 +21,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-add-student.ejs
+++ b/school-login/views/teacher/teacher-add-student.ejs
@@ -10,13 +10,7 @@
     content: function () { %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-bulk-grade-template.ejs
+++ b/school-login/views/teacher/teacher-bulk-grade-template.ejs
@@ -16,13 +16,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-class-statistics.ejs
+++ b/school-login/views/teacher/teacher-class-statistics.ejs
@@ -46,13 +46,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-classes.ejs
+++ b/school-login/views/teacher/teacher-classes.ejs
@@ -11,13 +11,7 @@
     <button class="mobile-nav-toggle" aria-label="Navigation öffnen"></button>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-create-class.ejs
+++ b/school-login/views/teacher/teacher-create-class.ejs
@@ -10,13 +10,7 @@
     content: function () { %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-create-template.ejs
+++ b/school-login/views/teacher/teacher-create-template.ejs
@@ -14,13 +14,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-edit-template.ejs
+++ b/school-login/views/teacher/teacher-edit-template.ejs
@@ -14,13 +14,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-grade-templates.ejs
+++ b/school-login/views/teacher/teacher-grade-templates.ejs
@@ -35,13 +35,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-grades.ejs
+++ b/school-login/views/teacher/teacher-grades.ejs
@@ -11,13 +11,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-settings.ejs
+++ b/school-login/views/teacher/teacher-settings.ejs
@@ -25,13 +25,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-special-assessments.ejs
+++ b/school-login/views/teacher/teacher-special-assessments.ejs
@@ -46,13 +46,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> · Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-student-grade-details.ejs
+++ b/school-login/views/teacher/teacher-student-grade-details.ejs
@@ -13,13 +13,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-student-grades.ejs
+++ b/school-login/views/teacher/teacher-student-grades.ejs
@@ -46,13 +46,7 @@
 %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-students.ejs
+++ b/school-login/views/teacher/teacher-students.ejs
@@ -10,13 +10,7 @@
     content: function () { %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">

--- a/school-login/views/teacher/teacher-test-questions.ejs
+++ b/school-login/views/teacher/teacher-test-questions.ejs
@@ -10,13 +10,7 @@
     content: function () { %>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
-        <div class="sidebar-brand">
-          <div>
-            <div class="sidebar-title">Teacher Panel</div>
-            <div class="sidebar-meta"><%= email %> - Lehrer</div>
-          </div>
-          <span class="sidebar-badge">Eingeloggt</span>
-        </div>
+        <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">


### PR DESCRIPTION
Improved the dashboard/header user info card across all roles by replacing technical labels like Teacher Panel, Student Panel, and Admin Panel with a cleaner, user-friendly display. The card now shows the user’s formatted display name as the main title, a readable localized role label (Administrator, Schüler, Lehrer) underneath, and a compact HTLWY badge on the right. A central helper was added to derive proper names from emails in the format vorname.nachname@..., apply readable fallbacks when needed, and keep the logic maintainable and reusable across Admin, Student, and Teacher views.