### PR TITLE
umlaute problem fixed

### DIFF
--- a/school-login/controllers/archiveController.js
+++ b/school-login/controllers/archiveController.js
@@ -118,7 +118,7 @@ const archiveCsvConfigs = {
     columns: [
       { header: "ID", key: "id" },
       { header: "Archivtyp", key: "archive_type" },
-      { header: "Anzahl Eintraege", key: "entity_count" },
+      { header: "Anzahl Einträge", key: "entity_count" },
       { header: "Erstellt am", key: "created_at" }
     ]
   },
@@ -128,7 +128,7 @@ const archiveCsvConfigs = {
     columns: [
       { header: "Klasse", key: "class_name" },
       { header: "Fach", key: "subject_name" },
-      { header: "Lehrkraefte", key: "teacher_names" }
+      { header: "Lehrkräfte", key: "teacher_names" }
     ]
   },
   classes: {
@@ -148,7 +148,7 @@ const archiveCsvConfigs = {
     columns: [
       { header: "ID", key: "id" },
       { header: "Klasse", key: "class_name" },
-      { header: "Schueler", key: "student_name" },
+      { header: "Schüler", key: "student_name" },
       { header: "Fach", key: "subject" },
       { header: "Note", key: "grade" },
       { header: "Kommentar", value: (row) => row.note || "" },
@@ -219,7 +219,7 @@ async function downloadArchiveCsv(req, res, next) {
 
     if (!selectedSchoolYear) {
       return res.status(404).render("error", {
-        message: "Kein Schuljahr fuer den Export verfuegbar.",
+        message: "Kein Schuljahr für den Export verfügbar.",
         status: 404,
         backUrl: "/archive"
       });

--- a/school-login/controllers/assignmentController.js
+++ b/school-login/controllers/assignmentController.js
@@ -143,7 +143,7 @@ async function getClassTeachers(req, res, next) {
     const classId = Number(req.params.classId);
     const subjectId = Number(req.query.subject_id) || null;
     if (!Number.isInteger(classId) || classId <= 0) {
-      return res.status(400).json({ error: "Ungueltige Klasse." });
+      return res.status(400).json({ error: "Ungültige Klasse." });
     }
     const rows = await assignmentModel.listAssignmentRows();
     const teacherIds = rows
@@ -177,7 +177,7 @@ async function createAssignment(req, res, next) {
 
     if (!Number.isInteger(classId) || teacherIds.length === 0) {
       return flashAndRedirect(req, res, redirectUrl, {
-        error: "Bitte Klasse und mindestens einen Lehrer waehlen.",
+        error: "Bitte Klasse und mindestens einen Lehrer wählen.",
         formData: flashFormData
       });
     }
@@ -199,7 +199,7 @@ async function createAssignment(req, res, next) {
       return flashAndRedirect(req, res, redirectUrl, {
         error: newSubjectName
           ? "Fach konnte nicht angelegt werden."
-          : "Bitte ein bestehendes Fach waehlen oder ein neues Fach anlegen.",
+          : "Bitte ein bestehendes Fach wählen oder ein neues Fach anlegen.",
         formData: flashFormData
       });
     }
@@ -216,7 +216,7 @@ async function createAssignment(req, res, next) {
     const validTeacherIds = teacherRows.map((row) => Number(row.id));
     if (!validTeacherIds.length) {
       return flashAndRedirect(req, res, redirectUrl, {
-        error: "Keine gueltigen Lehrer ausgewaehlt.",
+        error: "Keine gültigen Lehrer ausgewählt.",
         formData: flashFormData
       });
     }
@@ -241,7 +241,7 @@ async function deleteAssignment(req, res, next) {
     const assignmentId = Number(req.body?.assignment_id);
     if (!Number.isInteger(assignmentId) || assignmentId <= 0) {
       return flashAndRedirect(req, res, "/admin/assignments", {
-        error: "Ungueltige Zuordnung."
+        error: "Ungültige Zuordnung."
       });
     }
 

--- a/school-login/controllers/rolloverController.js
+++ b/school-login/controllers/rolloverController.js
@@ -5,8 +5,8 @@ const ROLLOVER_WIZARD_SESSION_KEY = "rolloverWizard";
 const ROLLOVER_STEPS = [
   { key: "start", label: "Start" },
   { key: "classes", label: "Klassen" },
-  { key: "students", label: "Schueler" },
-  { key: "review", label: "Pruefen" }
+  { key: "students", label: "Schüler" },
+  { key: "review", label: "Prüfen" }
 ];
 
 function normalizeStep(value) {
@@ -207,7 +207,7 @@ async function saveStudentStep(req, res, next) {
     if (shouldAdvance && hasBlockingErrors) {
       return renderRolloverPage(req, res, next, {
         step: "students",
-        error: result.validation.errors[0] || "Bitte Eingaben im Schueler-Schritt pruefen.",
+        error: result.validation.errors[0] || "Bitte Eingaben im Schüler-Schritt prüfen.",
         intakeParseErrors: result.intakeParseErrors
       });
     }
@@ -216,7 +216,7 @@ async function saveStudentStep(req, res, next) {
   } catch (err) {
     return renderRolloverPage(req, res, next, {
       step: "students",
-      error: err.message || "Schuelerplanung konnte nicht gespeichert werden."
+      error: err.message || "Schülerplanung konnte nicht gespeichert werden."
     });
   }
 }
@@ -225,11 +225,11 @@ async function resetWizard(req, res, next) {
   try {
     clearWizardDraft(req);
     await saveSession(req);
-    return res.redirect("/admin/rollover?step=start&message=Rollover-Assistent wurde zurueckgesetzt.");
+    return res.redirect("/admin/rollover?step=start&message=Rollover-Assistent wurde zurückgesetzt.");
   } catch (err) {
     return renderRolloverPage(req, res, next, {
       step: "start",
-      error: err.message || "Assistent konnte nicht zurueckgesetzt werden."
+      error: err.message || "Assistent konnte nicht zurückgesetzt werden."
     });
   }
 }
@@ -247,12 +247,12 @@ async function executeRollover(req, res, next) {
     await saveSession(req);
 
     return res.redirect(`/admin/rollover?step=start&message=${encodeURIComponent(
-      `Schuljahreswechsel nach ${executionResult.preview.nextSchoolYear.name} erfolgreich ausgefuehrt.`
+      `Schuljahreswechsel nach ${executionResult.preview.nextSchoolYear.name} erfolgreich ausgeführt.`
     )}`);
   } catch (err) {
     return renderRolloverPage(req, res, next, {
       step: "review",
-      error: err.message || "Schuljahreswechsel konnte nicht ausgefuehrt werden."
+      error: err.message || "Schuljahreswechsel konnte nicht ausgeführt werden."
     });
   }
 }
@@ -264,11 +264,11 @@ async function restoreSchoolYear(req, res, next) {
     const logRow = logs.find((entry) => Number(entry.id) === logId);
 
     if (!logRow || !logRow.backup_path) {
-      throw new Error("Ausgewaehlter Backup-Eintrag wurde nicht gefunden.");
+      throw new Error("Ausgewählter Backup-Eintrag wurde nicht gefunden.");
     }
 
     if (String(logRow.status || "").toLowerCase() !== "success") {
-      throw new Error("Nur erfolgreiche Schuljahreswechsel koennen wiederhergestellt werden.");
+      throw new Error("Nur erfolgreiche Schuljahreswechsel können wiederhergestellt werden.");
     }
 
     const restoreResult = await rolloverService.restoreSchoolYearFromBackup({
@@ -280,7 +280,7 @@ async function restoreSchoolYear(req, res, next) {
     await saveSession(req);
 
     return res.redirect(`/admin/rollover?step=start&message=${encodeURIComponent(
-      `${restoreResult.targetSchoolYearName} wurde auf ${restoreResult.previousSchoolYearName} zurueckgesetzt.`
+      `${restoreResult.targetSchoolYearName} wurde auf ${restoreResult.previousSchoolYearName} zurückgesetzt.`
     )}`);
   } catch (err) {
     return renderRolloverPage(req, res, next, {

--- a/school-login/middleware/audit.js
+++ b/school-login/middleware/audit.js
@@ -24,7 +24,7 @@ const SUMMARY_LABELS = {
   profile_name: "Profil",
   scoring_mode: "Bewertung",
   absence_mode: "Abwesenheit",
-  student_id: "Schueler",
+  student_id: "Schüler",
   type: "Typ",
   category: "Kategorie",
   weight: "Gewichtung",
@@ -46,7 +46,7 @@ const SUMMARY_LABELS = {
   head_teacher_id: "Klassenvorstand",
   id: "ID",
   classId: "Klasse",
-  studentId: "Schueler",
+  studentId: "Schüler",
   profileId: "Profil",
   gradeId: "Note",
   templateId: "Vorlage",
@@ -56,10 +56,10 @@ const SUMMARY_LABELS = {
 const VALUE_LABELS = {
   admin: "Admin",
   teacher: "Lehrer",
-  student: "Schueler",
+  student: "Schüler",
   active: "Aktiv",
   locked: "Gesperrt",
-  deleted: "Geloescht",
+  deleted: "Gelöscht",
   points_or_grade: "Punkte oder Note",
   points_and_grade: "Punkte und Note",
   points_only: "Nur Punkte",
@@ -71,13 +71,13 @@ const VALUE_LABELS = {
   Wiederholung: "Wiederholung",
   Mitarbeit: "Mitarbeit",
   Projekt: "Projekt",
-  Hausuebung: "Hausuebung",
+  Hausübung: "Hausübung",
   Hausaufgabe: "Hausaufgabe",
-  Praesentation: "Praesentation",
-  Wunschpruefung: "Wunschpruefung",
+  Präsentation: "Präsentation",
+  Wunschprüfung: "Wunschprüfung",
   Benutzerdefiniert: "Benutzerdefiniert",
-  include: "Einschliessen",
-  exclude: "Ausschliessen",
+  include: "Einschließen",
+  exclude: "Ausschließen",
   plus: "+",
   plus_tilde: "+/-",
   neutral: "neutral",
@@ -87,9 +87,9 @@ const VALUE_LABELS = {
 const ENTITY_LABELS = {
   user: "Benutzer",
   class: "Klasse",
-  student: "Schueler",
+  student: "Schüler",
   assignment: "Fachzuordnung",
-  exam_template: "Pruefung",
+  exam_template: "Prüfung",
   grade: "Note",
   special_assessment: "Sonderleistung",
   participation: "Mitarbeit",
@@ -176,7 +176,7 @@ function formatSummaryValue(key, value) {
   if (value == null || value === "") return null;
 
   if (Array.isArray(value)) {
-    return value.length ? `${value.length} Eintraege` : null;
+    return value.length ? `${value.length} Einträge` : null;
   }
 
   if (typeof value === "boolean") {
@@ -271,13 +271,13 @@ function buildScopeLabel(routePath, entityType) {
   if (normalizedPath.startsWith("/admin/assignments")) return "Admin / Fachzuordnungen";
   if (normalizedPath.startsWith("/admin/audit-logs")) return "Admin / Audit";
   if (normalizedPath.startsWith("/teacher/settings")) return "Teacher / Einstellungen";
-  if (normalizedPath.startsWith("/teacher/grade-templates") || normalizedPath.startsWith("/teacher/create-template") || normalizedPath.startsWith("/teacher/edit-template") || normalizedPath.startsWith("/teacher/bulk-grade-template")) return "Teacher / Pruefungen";
+  if (normalizedPath.startsWith("/teacher/grade-templates") || normalizedPath.startsWith("/teacher/create-template") || normalizedPath.startsWith("/teacher/edit-template") || normalizedPath.startsWith("/teacher/bulk-grade-template")) return "Teacher / Prüfungen";
   if (normalizedPath.startsWith("/teacher/add-grade") || normalizedPath.startsWith("/teacher/grades") || normalizedPath.startsWith("/teacher/delete-grade")) return "Teacher / Noten";
   if (normalizedPath.startsWith("/teacher/special-assessments")) return "Teacher / Sonderleistungen";
-  if (normalizedPath.startsWith("/teacher/students") || normalizedPath.startsWith("/teacher/add-student") || normalizedPath.startsWith("/teacher/delete-student") || normalizedPath.startsWith("/teacher/student-exclusion")) return "Teacher / Schueler";
-  if (normalizedPath.startsWith("/teacher/classes") || normalizedPath.startsWith("/teacher/create-class") || normalizedPath.startsWith("/teacher/delete-class")) return "Teacher / Faecher";
-  if (normalizedPath.startsWith("/teacher/test-questions")) return "Teacher / Rueckfragen";
-  if (normalizedPath.startsWith("/student/returns")) return "Student / Rueckgaben";
+  if (normalizedPath.startsWith("/teacher/students") || normalizedPath.startsWith("/teacher/add-student") || normalizedPath.startsWith("/teacher/delete-student") || normalizedPath.startsWith("/teacher/student-exclusion")) return "Teacher / Schüler";
+  if (normalizedPath.startsWith("/teacher/classes") || normalizedPath.startsWith("/teacher/create-class") || normalizedPath.startsWith("/teacher/delete-class")) return "Teacher / Fächer";
+  if (normalizedPath.startsWith("/teacher/test-questions")) return "Teacher / Rückfragen";
+  if (normalizedPath.startsWith("/student/returns")) return "Student / Rückgaben";
   if (normalizedPath.startsWith("/student/notifications")) return "Student / Benachrichtigungen";
 
   const parts = normalizedPath.split("/").filter(Boolean);
@@ -334,14 +334,14 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/admin\/users\/[^/]+\/reset$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: body.useInitial === "1" ? "Passwort auf Initial-Passwort gesetzt" : "Passwort geaendert",
+      actionTitle: body.useInitial === "1" ? "Passwort auf Initial-Passwort gesetzt" : "Passwort geändert",
       targetLabel: entityTarget
     });
   }
   if (/^\/admin\/users\/[^/]+\/delete$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Benutzer geloescht",
+      actionTitle: "Benutzer gelöscht",
       targetLabel: entityTarget
     });
   }
@@ -364,14 +364,14 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/admin\/classes\/[^/]+\/delete$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Klasse geloescht",
+      actionTitle: "Klasse gelöscht",
       targetLabel: entityTarget
     });
   }
   if (/^\/admin\/classes\/[^/]+\/students\/add$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Schueler zur Klasse hinzugefuegt",
+      actionTitle: "Schüler zur Klasse hinzugefügt",
       targetLabel: buildTargetLabel(getFormattedSourceValue(body, "email"), getFormattedSourceValue(body, "name"), buildEntityTarget("student", params.studentId)),
       detailEntries: buildSummaryFromSource(params, ["id"])
     });
@@ -379,15 +379,15 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/admin\/classes\/[^/]+\/students\/add-bulk$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Schueler gesammelt zur Klasse hinzugefuegt",
-      targetLabel: buildTargetLabel(getFormattedSourceValue(body, "bulkEmails"), "Mehrere Schueler"),
+      actionTitle: "Schüler gesammelt zur Klasse hinzugefügt",
+      targetLabel: buildTargetLabel(getFormattedSourceValue(body, "bulkEmails"), "Mehrere Schüler"),
       detailEntries: buildSummaryFromSource(params, ["id"])
     });
   }
   if (/^\/admin\/classes\/[^/]+\/students\/[^/]+\/delete$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Schueler aus Klasse entfernt",
+      actionTitle: "Schüler aus Klasse entfernt",
       targetLabel: buildEntityTarget("student", params.studentId),
       detailEntries: buildSummaryFromSource(params, ["classId"])
     });
@@ -418,14 +418,14 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/add-student\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Schueler hinzugefuegt",
+      actionTitle: "Schüler hinzugefügt",
       targetLabel: buildTargetLabel(getFormattedSourceValue(body, "email"), getFormattedSourceValue(body, "name"), entityTarget)
     });
   }
   if (/^\/teacher\/delete-student\/[^/]+\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Schueler entfernt",
+      actionTitle: "Schüler entfernt",
       targetLabel: buildEntityTarget("student", params.studentId),
       detailEntries: buildSummaryFromSource(params, ["classId"])
     });
@@ -434,7 +434,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
     const actionValue = String(body.action || "").trim().toLowerCase();
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: actionValue === "include" ? "Schueler im Fach eingeschlossen" : "Schueler im Fach ausgeschlossen",
+      actionTitle: actionValue === "include" ? "Schüler im Fach eingeschlossen" : "Schüler im Fach ausgeschlossen",
       targetLabel: buildEntityTarget("student", params.studentId),
       detailEntries: [
         buildSummaryFromSource(params, ["classId"]),
@@ -460,15 +460,15 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/settings\/delete-profile\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Benotungsprofil geloescht",
+      actionTitle: "Benotungsprofil gelöscht",
       targetLabel: buildEntityTarget("system", params.profileId)
     });
   }
   if (/^\/teacher\/students\/[^/]+\/messages\/[^/]+\/reply$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Antwort auf Rueckfrage gesendet",
-      targetLabel: buildEntityTarget("student", params.studentId) || "Rueckfrage",
+      actionTitle: "Antwort auf Rückfrage gesendet",
+      targetLabel: buildEntityTarget("student", params.studentId) || "Rückfrage",
       detailEntries: buildSummaryFromSource(body, ["reply"])
     });
   }
@@ -483,7 +483,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/delete-participation\/[^/]+\/[^/]+\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Mitarbeit geloescht",
+      actionTitle: "Mitarbeit gelöscht",
       targetLabel: buildEntityTarget("student", params.studentId),
       detailEntries: buildSummaryFromSource(params, ["markId"])
     });
@@ -491,7 +491,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/delete-grade\/[^/]+\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Note geloescht",
+      actionTitle: "Note gelöscht",
       targetLabel: buildEntityTarget("grade", params.gradeId),
       detailEntries: buildSummaryFromSource(params, ["classId"])
     });
@@ -516,7 +516,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/create-template\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Pruefung erstellt",
+      actionTitle: "Prüfung erstellt",
       targetLabel: buildTargetLabel(getFormattedSourceValue(body, "name"), entityTarget),
       detailEntries: buildSummaryFromSource(body, ["category", "weight", "max_points", "date"])
     });
@@ -524,7 +524,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/edit-template\/[^/]+\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Pruefung bearbeitet",
+      actionTitle: "Prüfung bearbeitet",
       targetLabel: buildTargetLabel(getFormattedSourceValue(body, "name"), buildEntityTarget("exam_template", params.templateId)),
       detailEntries: buildSummaryFromSource(body, ["category", "weight", "max_points", "date"])
     });
@@ -532,7 +532,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/delete-template\/[^/]+\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Pruefung geloescht",
+      actionTitle: "Prüfung gelöscht",
       targetLabel: buildEntityTarget("exam_template", params.templateId)
     });
   }
@@ -547,14 +547,14 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/teacher\/delete-special-assessment\/[^/]+\/[^/]+$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Sonderleistung geloescht",
+      actionTitle: "Sonderleistung gelöscht",
       targetLabel: buildEntityTarget("special_assessment", params.assessmentId)
     });
   }
   if (/^\/student\/returns\/[^/]+\/message$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Nachricht zur Rueckgabe gesendet",
+      actionTitle: "Nachricht zur Rückgabe gesendet",
       targetLabel: buildEntityTarget("grade", params.gradeId),
       detailEntries: buildSummaryFromSource(body, ["message"])
     });
@@ -562,7 +562,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/^\/student\/returns\/[^/]+\/messages\/seen$/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Rueckgabe-Nachrichten gelesen",
+      actionTitle: "Rückgabe-Nachrichten gelesen",
       targetLabel: buildEntityTarget("grade", params.gradeId)
     });
   }
@@ -578,7 +578,7 @@ function buildAuditDescription(req, routePath, entityType, entityId) {
   if (/delete|remove/i.test(routePath)) {
     return buildAuditEntry({
       scopeLabel,
-      actionTitle: "Eintrag geloescht",
+      actionTitle: "Eintrag gelöscht",
       targetLabel: entityTarget,
       detailEntries: fallbackSummary
     });

--- a/school-login/public/js/admin-audit-logs.js
+++ b/school-login/public/js/admin-audit-logs.js
@@ -36,7 +36,7 @@
   function updateCountBadge() {
     if (!countBadge) return;
     countBadge.dataset.totalCount = String(totalCount);
-    countBadge.textContent = `${totalCount} Eintraege`;
+    countBadge.textContent = `${totalCount} Einträge`;
   }
 
   function createCell(text) {
@@ -58,7 +58,7 @@
     const onlyRow = tbody.querySelector("tr");
     if (!onlyRow) return;
     if (tbody.querySelectorAll("tr").length !== 1) return;
-    if (!onlyRow.textContent.includes("Keine Audit-Eintraege")) return;
+    if (!onlyRow.textContent.includes("Keine Audit-Einträge")) return;
     tbody.innerHTML = "";
   }
 
@@ -134,7 +134,7 @@
       appendOlderLogs(data.logs || []);
       hasMoreOlder = Boolean(data.hasMore);
       if (!hasMoreOlder) {
-        sentinel.textContent = "Alle vorhandenen Eintraege wurden geladen.";
+        sentinel.textContent = "Alle vorhandenen Einträge wurden geladen.";
       }
     } catch (err) {
       sentinel.textContent = "Fehler beim Nachladen der Logs.";

--- a/school-login/public/js/app-modal.js
+++ b/school-login/public/js/app-modal.js
@@ -115,7 +115,7 @@
 
     lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
 
-    instance.title.textContent = options.title || "Bestaetigung";
+    instance.title.textContent = options.title || "Bestätigung";
     instance.message.textContent = options.message || "";
 
     if (options.note) {
@@ -169,8 +169,8 @@
   window.AppModal = {
     confirm: function (options) {
       return open(Object.assign({
-        title: "Bestaetigung",
-        confirmText: "Bestaetigen",
+        title: "Bestätigung",
+        confirmText: "Bestätigen",
         cancelText: "Abbrechen",
         intent: "danger",
         hideCancel: false
@@ -200,10 +200,10 @@
     event.preventDefault();
 
     window.AppModal.confirm({
-      title: form.dataset.confirmTitle || "Bestaetigung",
+      title: form.dataset.confirmTitle || "Bestätigung",
       message: form.dataset.confirmMessage,
       note: form.dataset.confirmNote || "",
-      confirmText: form.dataset.confirmAction || "Bestaetigen",
+      confirmText: form.dataset.confirmAction || "Bestätigen",
       cancelText: form.dataset.confirmCancel || "Abbrechen",
       intent: form.dataset.confirmVariant === "primary" ? "primary" : "danger"
     }).then(function (confirmed) {

--- a/school-login/public/js/student-dashboard.js
+++ b/school-login/public/js/student-dashboard.js
@@ -55,7 +55,7 @@
   function normalizeReturn(entry) {
     return {
       ...entry,
-      title: entry.title || "Rueckgabe",
+      title: entry.title || "Rückgabe",
       category: entry.category || "",
       subject: entry.subject || "",
       note: entry.note || "",
@@ -217,7 +217,7 @@
     if (stats.totalCount > 0) {
       return { label: "Beantwortet", className: "answered" };
     }
-    return { label: "Noch keine Rueckfrage", className: "idle" };
+    return { label: "Noch keine Rückfrage", className: "idle" };
   }
 
   function getTaskStatus(task) {
@@ -226,7 +226,7 @@
     }
     const due = task.due_at ? new Date(task.due_at) : null;
     if (due && !Number.isNaN(due.getTime()) && due < new Date()) {
-      return { label: "Ueberfaellig", className: "overdue" };
+      return { label: "Überfällig", className: "overdue" };
     }
     return { label: "Offen", className: "open" };
   }
@@ -414,7 +414,7 @@
 
     if (!items.length) {
       container.innerHTML =
-        '<p class="empty-state">Keine Fachdaten fuer die aktuellen Filter vorhanden.</p>';
+        '<p class="empty-state">Keine Fachdaten für die aktuellen Filter vorhanden.</p>';
       return;
     }
 
@@ -422,7 +422,7 @@
       <div class="subject-list-header">
         <span>Fach</span>
         <span>Durchschnitt</span>
-        <span>Eintraege</span>
+        <span>Einträge</span>
         <span>Letztes Update</span>
       </div>
     ` + items
@@ -450,8 +450,8 @@
     if (!selectedSubject) {
       container.innerHTML = `
         <div class="grade-subject-detail-empty">
-          <strong>Fach auswaehlen</strong>
-          <p>Waehle oben ein Fach, um den aktuellen Stand und das Beurteilungsprotokoll im Detail zu sehen.</p>
+          <strong>Fach auswählen</strong>
+          <p>Wähle oben ein Fach, um den aktuellen Stand und das Beurteilungsprotokoll im Detail zu sehen.</p>
         </div>
       `;
       return;
@@ -477,7 +477,7 @@
         </div>
         <div class="overview-stats-strip">
           <div class="stat-inline"><span class="stat-inline-label">Fachdurchschnitt</span><strong class="stat-inline-value">${averages.overall == null ? "-" : Number(averages.overall).toFixed(2)}</strong></div>
-          <div class="stat-inline"><span class="stat-inline-label">Eintraege</span><strong class="stat-inline-value">${subjectGrades.length}</strong></div>
+          <div class="stat-inline"><span class="stat-inline-label">Einträge</span><strong class="stat-inline-value">${subjectGrades.length}</strong></div>
           <div class="stat-inline"><span class="stat-inline-label">Letzte Bewertung</span><strong class="stat-inline-value">${latest?.value == null ? "-" : formatGradeValue(latest.value)}</strong></div>
           <div class="stat-inline"><span class="stat-inline-label">Klassenvergleich</span><strong class="stat-inline-value">${classAverage == null ? "-" : Number(classAverage).toFixed(2)}</strong></div>
         </div>
@@ -494,11 +494,11 @@
 
     if (!selectedSubject) {
       const subjectCount = getSubjectOverviewItems(baseGrades).length;
-      const subjectLabel = subjectCount === 1 ? "Fach" : "Faecher";
+      const subjectLabel = subjectCount === 1 ? "Fach" : "Fächer";
       title.textContent = "Beurteilungsprotokoll";
       copy.textContent = !visibleGrades.length
-        ? "Keine sichtbaren Eintraege fuer die aktuellen Filter."
-        : `${visibleGrades.length} sichtbare Eintraege ueber ${subjectCount} ${subjectLabel}. Waehle oben ein Fach fuer Details und deinen aktuellen Stand.`;
+        ? "Keine sichtbaren Einträge für die aktuellen Filter."
+        : `${visibleGrades.length} sichtbare Einträge über ${subjectCount} ${subjectLabel}. Wähle oben ein Fach für Details und deinen aktuellen Stand.`;
       return;
     }
 
@@ -506,11 +506,11 @@
     const classAverage = getClassAverageForSubject(selectedSubject)?.average ?? null;
     const averageText = averages.overall == null ? "-" : Number(averages.overall).toFixed(2);
     const classAverageText =
-      classAverage == null ? "kein Klassenschnitt verfuegbar" : `Klassenschnitt ${Number(classAverage).toFixed(2)}`;
+      classAverage == null ? "kein Klassenschnitt verfügbar" : `Klassenschnitt ${Number(classAverage).toFixed(2)}`;
     title.textContent = `Beurteilungsprotokoll: ${selectedSubject}`;
     copy.textContent = !visibleGrades.length
-      ? `Keine sichtbaren Eintraege fuer ${selectedSubject}.`
-      : `${visibleGrades.length} sichtbare Eintraege, aktueller Stand ${averageText}, ${classAverageText}.`;
+      ? `Keine sichtbaren Einträge für ${selectedSubject}.`
+      : `${visibleGrades.length} sichtbare Einträge, aktueller Stand ${averageText}, ${classAverageText}.`;
   }
 
   function setText(id, value) {
@@ -597,7 +597,7 @@
       const selectedSubject = getGradeFilterValues().subject;
       container.innerHTML = `<p class="empty-state">${
         selectedSubject
-          ? `Keine Noten fuer ${escapeHtml(selectedSubject)} mit den aktuellen Filtern vorhanden.`
+          ? `Keine Noten für ${escapeHtml(selectedSubject)} mit den aktuellen Filtern vorhanden.`
           : "Keine Noten vorhanden."
       }</p>`;
       return;
@@ -693,7 +693,7 @@
               <div class="overview-row">
                 <div class="overview-row-main">
                   ${buildRowHead(task.title, task.subject, task.category)}
-                  ${buildMetaLine([`Faellig: ${formatDate(task.due_at)}`])}
+                  ${buildMetaLine([`Fällig: ${formatDate(task.due_at)}`])}
                 </div>
                 <div class="overview-row-side">
                   <span class="status-pill ${getTaskStatus(task).className}">${getTaskStatus(task).label}</span>
@@ -748,7 +748,7 @@
 
       if (!recentReturns.length) {
         recentReturnsContainer.innerHTML =
-          '<p class="empty-state">Noch keine Rueckgaben vorhanden.</p>';
+          '<p class="empty-state">Noch keine Rückgaben vorhanden.</p>';
       } else {
         recentReturnsContainer.innerHTML = recentReturns
           .map((entry) => {
@@ -759,7 +759,7 @@
                 <div class="overview-row-main">
                   ${buildRowHead(entry.title, entry.subject, entry.category)}
                   ${buildMetaLine([
-                    `Rueckgabe: ${formatDate(entry.graded_at)}`,
+                    `Rückgabe: ${formatDate(entry.graded_at)}`,
                     `${stats.totalCount} Nachricht${stats.totalCount === 1 ? "" : "en"}`
                   ])}
                 </div>
@@ -849,7 +849,7 @@
 
     if (!state.tasks.length) {
       setCount("task-count", 0);
-      container.innerHTML = '<p class="empty-state">Keine aktiven Pruefungen vorhanden.</p>';
+      container.innerHTML = '<p class="empty-state">Keine aktiven Prüfungen vorhanden.</p>';
       return;
     }
 
@@ -864,7 +864,7 @@
     setCount("task-count", filtered.length);
 
     if (!filtered.length) {
-      container.innerHTML = '<p class="empty-state">Keine aktiven Pruefungen gefunden.</p>';
+      container.innerHTML = '<p class="empty-state">Keine aktiven Prüfungen gefunden.</p>';
       return;
     }
 
@@ -913,7 +913,7 @@
           <div class="row-main">
             ${buildRowHead(task.title, task.subject, task.category)}
             ${buildMetaLine([
-              `Faellig: ${formatDate(task.due_at)}`,
+              `Fällig: ${formatDate(task.due_at)}`,
               `Gewichtung: ${formatWeight(task.weight)}`,
               task.graded_at ? `Benotet: ${formatDate(task.graded_at)}` : ""
             ])}
@@ -942,7 +942,7 @@
           ${
             tasks.length
               ? tasks.map((task) => renderTaskRow(task)).join("")
-              : '<p class="empty-state">Keine Eintraege in diesem Bereich.</p>'
+              : '<p class="empty-state">Keine Einträge in diesem Bereich.</p>'
           }
         </div>
       </section>
@@ -951,12 +951,12 @@
     container.innerHTML = [
       renderTaskGroup(
         "Bevorstehend",
-        "Aufgaben mit Termin in den naechsten 14 Tagen.",
+        "Aufgaben mit Termin in den nächsten 14 Tagen.",
         groups.upcoming
       ),
       renderTaskGroup(
         "Weiter anstehend",
-        "Aufgaben mit spaeterem Termin. Eintraege ohne Datum stehen ebenfalls hier.",
+        "Aufgaben mit späterem Termin. Einträge ohne Datum stehen ebenfalls hier.",
         groups.later
       ),
       renderTaskGroup(
@@ -975,7 +975,7 @@
 
     if (!state.archivedTasks.length) {
       setCount("archive-count", 0);
-      container.innerHTML = '<p class="empty-state">Keine archivierten Pruefungen vorhanden.</p>';
+      container.innerHTML = '<p class="empty-state">Keine archivierten Prüfungen vorhanden.</p>';
       return;
     }
 
@@ -990,7 +990,7 @@
     setCount("archive-count", filtered.length);
 
     if (!filtered.length) {
-      container.innerHTML = '<p class="empty-state">Keine archivierten Pruefungen gefunden.</p>';
+      container.innerHTML = '<p class="empty-state">Keine archivierten Prüfungen gefunden.</p>';
       return;
     }
 
@@ -1006,7 +1006,7 @@
             <div class="row-main">
               ${buildRowHead(task.title, task.subject, task.category)}
               ${buildMetaLine([
-                `Pruefungsdatum: ${formatDate(task.due_at)}`,
+                `Prüfungsdatum: ${formatDate(task.due_at)}`,
                 `Gewichtung: ${formatWeight(task.weight)}`
               ])}
               ${task.description ? `<div class="nav-note">${escapeHtml(task.description)}</div>` : ""}
@@ -1048,7 +1048,7 @@
       (a, b) => dateSortValue(b.graded_at, 0) - dateSortValue(a.graded_at, 0)
     );
 
-    const options = ['<option value="">Alle Rueckgaben</option>'];
+    const options = ['<option value="">Alle Rückgaben</option>'];
     ordered.forEach((entry) => {
       const label = `${entry.subject ? `${entry.subject} | ` : ""}${entry.title}`;
       options.push(`<option value="${String(entry.id)}">${escapeHtml(label)}</option>`);
@@ -1089,14 +1089,14 @@
       const summary = document.createElement("summary");
       summary.className = "return-message-summary request-ticket-summary";
       const summaryLastActivity = stats.lastActivityAt
-        ? `Letzte Aktivitaet: ${formatDate(stats.lastActivityAt, true)}`
-        : "Noch keine Aktivitaet";
+        ? `Letzte Aktivität: ${formatDate(stats.lastActivityAt, true)}`
+        : "Noch keine Aktivität";
       const closedMeta = stats.closedAt
         ? `<span>Geschlossen: ${formatDate(stats.closedAt, true)}</span>`
         : "";
       summary.innerHTML = `
         <div class="return-summary-main">
-          <span>Rueckfragen</span>
+          <span>Rückfragen</span>
           <span class="return-status-pill ${status.className}">${status.label}</span>
         </div>
         <div class="return-summary-meta">
@@ -1125,7 +1125,7 @@
       thread.innerHTML = entry.messages.length
         ? `${entry.messages
             .map((message) => {
-              const studentAuthor = currentUserEmail || "Schueler";
+              const studentAuthor = currentUserEmail || "Schüler";
               const teacherAuthor =
                 message.teacher_reply_by_email || entry.teacher || "Lehrkraft";
               const teacherPart = message.teacher_reply
@@ -1154,7 +1154,7 @@
               `;
             })
             .join("")}${closedMessageHtml}`
-        : '<article class="return-message-row pending"><small>Noch keine Rueckfragen vorhanden.</small></article>';
+        : '<article class="return-message-row pending"><small>Noch keine Rückfragen vorhanden.</small></article>';
       details.appendChild(thread);
 
       if (entry.can_message) {
@@ -1268,7 +1268,7 @@
 
     if (!state.returns.length) {
       setCount("return-count", 0);
-      container.innerHTML = '<p class="empty-state">Keine Rueckgaben vorhanden.</p>';
+      container.innerHTML = '<p class="empty-state">Keine Rückgaben vorhanden.</p>';
       return;
     }
 
@@ -1283,7 +1283,7 @@
     setCount("return-count", filtered.length);
 
     if (!filtered.length) {
-      container.innerHTML = '<p class="empty-state">Keine Rueckgaben gefunden.</p>';
+      container.innerHTML = '<p class="empty-state">Keine Rückgaben gefunden.</p>';
       return;
     }
 
@@ -1301,7 +1301,7 @@
         const externalLink = entry.external_link ? escapeHtml(entry.external_link) : "";
         const attachmentName = entry.attachment_name ? escapeHtml(entry.attachment_name) : "Datei";
         const attachmentHtml = externalLink
-          ? `<div class="return-actions"><a class="btn small secondary" href="${externalLink}" target="_blank" rel="noopener noreferrer">Link oeffnen</a></div>`
+          ? `<div class="return-actions"><a class="btn small secondary" href="${externalLink}" target="_blank" rel="noopener noreferrer">Link öffnen</a></div>`
           : downloadUrl
             ? `<div class="return-actions"><a class="btn small secondary" href="${downloadUrl}">Datei herunterladen</a><small>${attachmentName}</small></div>`
             : "";
@@ -1314,14 +1314,14 @@
             <div class="row-main">
               ${buildRowHead(entry.title, entry.subject, entry.category)}
               ${buildMetaLine([
-                `Rueckgabe: ${formatDate(entry.graded_at, true)}`,
+                `Rückgabe: ${formatDate(entry.graded_at, true)}`,
                 `Gewichtung: ${formatWeight(entry.weight)}`
               ])}
               <div class="return-insights">
                 <span class="return-status-pill ${status.className}">${status.label}</span>
                 <span>${stats.totalCount} Nachricht${stats.totalCount === 1 ? "" : "en"}</span>
-                <span>Letzte Aktivitaet: ${
-                  stats.lastActivityAt ? formatDate(stats.lastActivityAt, true) : "Noch keine Rueckfragen"
+                <span>Letzte Aktivität: ${
+                  stats.lastActivityAt ? formatDate(stats.lastActivityAt, true) : "Noch keine Rückfragen"
                 }</span>
                 ${stats.closedAt ? `<span>Geschlossen: ${formatDate(stats.closedAt, true)}</span>` : ""}
               </div>
@@ -1357,7 +1357,7 @@
     if (!sourceEntries.length) {
       setCount("request-count", 0);
       container.innerHTML =
-        '<p class="empty-state">Noch keine Tickets vorhanden. Neue Anfragen startest du direkt bei der jeweiligen Rueckgabe.</p>';
+        '<p class="empty-state">Noch keine Tickets vorhanden. Neue Anfragen startest du direkt bei der jeweiligen Rückgabe.</p>';
       return;
     }
 
@@ -1411,7 +1411,7 @@
         const status = getReturnStatus(stats);
         const deleteButtonHtml =
           Array.isArray(entry.messages) && entry.messages.length > 0 && !stats.closedAt
-            ? `<button class="btn small secondary request-delete-button" type="button" data-request-delete="${String(entry.id)}">Anfrage schliessen</button>`
+            ? `<button class="btn small secondary request-delete-button" type="button" data-request-delete="${String(entry.id)}">Anfrage schließen</button>`
             : "";
         return `
           <article class="request-card request-row" data-grade-id="${String(entry.id)}">
@@ -1420,7 +1420,7 @@
                 <div class="row-main">
                   ${buildRowHead(entry.title, entry.subject, entry.category)}
                   ${buildMetaLine([
-                    `Rueckgabe: ${formatDate(entry.graded_at, true)}`,
+                    `Rückgabe: ${formatDate(entry.graded_at, true)}`,
                     `Gewichtung: ${formatWeight(entry.weight)}`
                   ])}
                 </div>
@@ -1432,8 +1432,8 @@
               <div class="return-insights">
                 <span class="return-status-pill ${status.className}">${status.label}</span>
                 <span>${stats.totalCount} Nachricht${stats.totalCount === 1 ? "" : "en"}</span>
-                <span>Letzte Aktivitaet: ${
-                  stats.lastActivityAt ? formatDate(stats.lastActivityAt, true) : "Noch keine Rueckfragen"
+                <span>Letzte Aktivität: ${
+                  stats.lastActivityAt ? formatDate(stats.lastActivityAt, true) : "Noch keine Rückfragen"
                 }</span>
               </div>
               ${entry.note ? `<div class="nav-note request-note">${escapeHtml(entry.note)}</div>` : ""}
@@ -1458,7 +1458,7 @@
           await loadReturnsFromServer();
         } catch (err) {
           console.error(err);
-          window.alert(err.message || "Ticket konnte nicht geloescht werden.");
+          window.alert(err.message || "Ticket konnte nicht gelöscht werden.");
           button.removeAttribute("disabled");
         }
       });
@@ -1552,7 +1552,7 @@
       renderRequests();
       renderOverview();
     } catch (err) {
-      console.error("Konnte Rueckgaben nicht laden:", err);
+      console.error("Konnte Rückgaben nicht laden:", err);
     }
   }
 

--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -13,9 +13,9 @@ const AUDIT_PAGE_SIZE = 50;
 const AUDIT_ENTITY_LABELS = {
   user: "Benutzer",
   class: "Klasse",
-  student: "Schueler",
+  student: "Schüler",
   assignment: "Fachzuordnung",
-  exam_template: "Pruefung",
+  exam_template: "Prüfung",
   grade: "Note",
   special_assessment: "Sonderleistung",
   participation: "Mitarbeit",
@@ -54,7 +54,7 @@ const AUDIT_FIELD_LABELS = {
   profile_name: "Profil",
   scoring_mode: "Bewertung",
   absence_mode: "Abwesenheit",
-  student_id: "Schueler",
+  student_id: "Schüler",
   type: "Typ",
   category: "Kategorie",
   weight: "Gewichtung",
@@ -75,7 +75,7 @@ const AUDIT_FIELD_LABELS = {
   id: "ID",
   classId: "Klasse",
   class_id: "Klasse",
-  studentId: "Schueler",
+  studentId: "Schüler",
   profileId: "Profil",
   gradeId: "Note",
   templateId: "Vorlage",
@@ -89,23 +89,23 @@ const AUDIT_VALUE_LABELS = {
   student: "Student",
   active: "Aktiv",
   locked: "Gesperrt",
-  deleted: "Geloescht",
+  deleted: "Gelöscht",
   points_or_grade: "Punkte oder Note",
   points_and_grade: "Punkte und Note",
   points_only: "Nur Punkte",
   grade_only: "Nur Note",
   include_zero: "Mit 0 bewerten",
   exclude: "Nicht werten",
-  include: "Einschliessen",
+  include: "Einschließen",
   Schularbeit: "Schularbeit",
   Test: "Test",
   Wiederholung: "Wiederholung",
   Mitarbeit: "Mitarbeit",
   Projekt: "Projekt",
-  Hausuebung: "Hausuebung",
+  Hausübung: "Hausübung",
   Hausaufgabe: "Hausaufgabe",
-  Praesentation: "Praesentation",
-  Wunschpruefung: "Wunschpruefung",
+  Präsentation: "Präsentation",
+  Wunschprüfung: "Wunschprüfung",
   Benutzerdefiniert: "Benutzerdefiniert",
   plus: "+",
   plus_tilde: "+/-",
@@ -242,7 +242,7 @@ function validateAuditRegexFilters(filters = {}) {
     try {
       new RegExp(value, "i");
     } catch {
-      return `Ungueltiger Regex in ${label}.`;
+      return `Ungültiger Regex in ${label}.`;
     }
   }
 
@@ -396,12 +396,12 @@ function buildAuditScopeFallback(routePath, entityType) {
   if (normalized.startsWith("/admin/classes")) return "Admin / Klassen";
   if (normalized.startsWith("/admin/assignments")) return "Admin / Fachzuordnungen";
   if (normalized.startsWith("/teacher/settings")) return "Teacher / Einstellungen";
-  if (normalized.startsWith("/teacher/create-template") || normalized.startsWith("/teacher/edit-template") || normalized.startsWith("/teacher/grade-templates") || normalized.startsWith("/teacher/bulk-grade-template")) return "Teacher / Pruefungen";
+  if (normalized.startsWith("/teacher/create-template") || normalized.startsWith("/teacher/edit-template") || normalized.startsWith("/teacher/grade-templates") || normalized.startsWith("/teacher/bulk-grade-template")) return "Teacher / Prüfungen";
   if (normalized.startsWith("/teacher/add-grade") || normalized.startsWith("/teacher/grades") || normalized.startsWith("/teacher/delete-grade")) return "Teacher / Noten";
-  if (normalized.startsWith("/teacher/students") || normalized.startsWith("/teacher/add-student") || normalized.startsWith("/teacher/delete-student") || normalized.startsWith("/teacher/student-exclusion")) return "Teacher / Schueler";
+  if (normalized.startsWith("/teacher/students") || normalized.startsWith("/teacher/add-student") || normalized.startsWith("/teacher/delete-student") || normalized.startsWith("/teacher/student-exclusion")) return "Teacher / Schüler";
   if (normalized.startsWith("/teacher/special-assessments")) return "Teacher / Sonderleistungen";
-  if (normalized.startsWith("/teacher/classes") || normalized.startsWith("/teacher/create-class")) return "Teacher / Faecher";
-  if (normalized.startsWith("/teacher/test-questions")) return "Teacher / Rueckfragen";
+  if (normalized.startsWith("/teacher/classes") || normalized.startsWith("/teacher/create-class")) return "Teacher / Fächer";
+  if (normalized.startsWith("/teacher/test-questions")) return "Teacher / Rückfragen";
 
   const parts = normalized.split("/").filter(Boolean);
   if (parts.length >= 2) {
@@ -445,7 +445,7 @@ function formatAuditFieldValue(key, value) {
   if (value == null || value === "") return null;
 
   if (Array.isArray(value)) {
-    return value.length ? `${value.length} Eintraege` : null;
+    return value.length ? `${value.length} Einträge` : null;
   }
 
   if (typeof value === "boolean") {
@@ -572,7 +572,7 @@ function buildAuditTargetFallback(entry, payload) {
     payload?.body?.type,
     payload?.params?.id ? `ID ${payload.params.id}` : null,
     payload?.params?.classId ? `Klasse ID ${payload.params.classId}` : null,
-    payload?.params?.studentId ? `Schueler ID ${payload.params.studentId}` : null
+    payload?.params?.studentId ? `Schüler ID ${payload.params.studentId}` : null
   ];
 
   for (const candidate of candidates) {
@@ -1026,7 +1026,7 @@ router.post("/users", async (req, res, next) => {
   if (!email || !normalizedRole || (!password && !wantsInitial)) {
     res.status(400);
     return renderCreateUserPage(req, res, {
-      error: "Bitte E-Mail, Rolle und eine gueltige Passwort-Option angeben.",
+      error: "Bitte E-Mail, Rolle und eine gültige Passwort-Option angeben.",
       mode: "single",
       singleForm
     });
@@ -1034,7 +1034,7 @@ router.post("/users", async (req, res, next) => {
   if (normalizedRole === "teacher" && wantsInitial) {
     res.status(400);
     return renderCreateUserPage(req, res, {
-      error: "Fuer Lehrer darf kein Initial-Passwort vergeben werden.",
+      error: "Für Lehrer darf kein Initial-Passwort vergeben werden.",
       mode: "single",
       singleForm
     });
@@ -1072,7 +1072,7 @@ router.post("/users", async (req, res, next) => {
   if (!email || !role || (!password && !wantsInitial)) {
     res.status(400);
     return renderCreateUserPage(req, res, {
-      error: "Bitte E-Mail, Rolle und eine gueltige Passwort-Option angeben.",
+      error: "Bitte E-Mail, Rolle und eine gültige Passwort-Option angeben.",
       mode: "single",
       singleForm
     });
@@ -1155,7 +1155,7 @@ router.post("/users/bulk", async (req, res, next) => {
   if (!normalizedBulkRole) {
     res.status(400);
     return renderCreateUserPage(req, res, {
-      error: "Bitte waehle eine Rolle fuer neue Nutzer.",
+      error: "Bitte wähle eine Rolle für neue Nutzer.",
       mode: "bulk",
       bulkForm
     });
@@ -1163,7 +1163,7 @@ router.post("/users/bulk", async (req, res, next) => {
   if (wantsInitial && normalizedBulkRole === "teacher") {
     res.status(400);
     return renderCreateUserPage(req, res, {
-      error: "Lehrer duerfen kein Initial-Passwort erhalten.",
+      error: "Lehrer dürfen kein Initial-Passwort erhalten.",
       mode: "bulk",
       bulkForm
     });
@@ -1902,7 +1902,7 @@ router.post("/classes/:id/students/add", async (req, res, next) => {
     const legacyUserRow = await getAsync("SELECT id, role FROM users WHERE email = ?", [resolvedEmail]);
     if (!legacyUserRow || legacyUserRow.role !== "student") {
       return renderAddStudentPage(req, res, classData, {
-        error: "E-Mail nicht gefunden oder nicht als Schueler registriert.",
+        error: "E-Mail nicht gefunden oder nicht als Schüler registriert.",
         mode: "single",
         singleForm: { name: resolvedName, email: resolvedEmail }
       });
@@ -1911,7 +1911,7 @@ router.post("/classes/:id/students/add", async (req, res, next) => {
     const legacyDuplicate = await getAsync("SELECT id FROM students WHERE email = ? AND class_id = ?", [resolvedEmail, classId]);
     if (legacyDuplicate) {
       return renderAddStudentPage(req, res, classData, {
-        error: "Dieser Schueler ist bereits in der Klasse.",
+        error: "Dieser Schüler ist bereits in der Klasse.",
         mode: "single",
         singleForm: { name: resolvedName, email: resolvedEmail }
       });
@@ -1924,7 +1924,7 @@ router.post("/classes/:id/students/add", async (req, res, next) => {
         csrfToken: req.csrfToken(),
         currentUser: req.session.user,
         activePath: `/admin/classes/${classId}/students/add`,
-        error: "E-Mail nicht gefunden oder nicht als SchÇ¬ler registriert.",
+        error: "E-Mail nicht gefunden oder nicht als Schüler registriert.",
         bulkResult: null
       });
     }
@@ -1936,7 +1936,7 @@ router.post("/classes/:id/students/add", async (req, res, next) => {
         csrfToken: req.csrfToken(),
         currentUser: req.session.user,
         activePath: `/admin/classes/${classId}/students/add`,
-        error: "Dieser SchÇ¬ler ist bereits in der Klasse.",
+        error: "Dieser Schüler ist bereits in der Klasse.",
         bulkResult: null
       });
     }

--- a/school-login/routes/student.js
+++ b/school-login/routes/student.js
@@ -817,7 +817,7 @@ router.post("/returns/:gradeId/message", async (req, res, next) => {
 
     const gradeId = Number(req.params.gradeId);
     if (!gradeId) {
-      return res.status(400).json({ error: "Ungueltige Rueckgabe-ID." });
+      return res.status(400).json({ error: "Ungültige Rückgabe-ID." });
     }
 
     const grade = await getAsync(
@@ -825,10 +825,10 @@ router.post("/returns/:gradeId/message", async (req, res, next) => {
       [gradeId, context.student.id]
     );
     if (!grade) {
-      return res.status(404).json({ error: "Rueckgabe nicht gefunden." });
+      return res.status(404).json({ error: "Rückgabe nicht gefunden." });
     }
     if (!grade.grade_template_id) {
-      return res.status(400).json({ error: "Nachrichten sind nur fuer Rueckgaben aus Pruefungen moeglich." });
+      return res.status(400).json({ error: "Nachrichten sind nur für Rückgaben aus Prüfungen möglich." });
     }
 
     const message = String(req.body?.message || "").trim();
@@ -864,7 +864,7 @@ router.post("/returns/:gradeId/messages/hide", async (req, res, next) => {
 
     const gradeId = Number(req.params.gradeId);
     if (!gradeId) {
-      return res.status(400).json({ error: "Ungueltige Rueckgabe-ID." });
+      return res.status(400).json({ error: "Ungültige Rückgabe-ID." });
     }
 
     const grade = await getAsync(
@@ -872,10 +872,10 @@ router.post("/returns/:gradeId/messages/hide", async (req, res, next) => {
       [gradeId, context.student.id]
     );
     if (!grade) {
-      return res.status(404).json({ error: "Rueckgabe nicht gefunden." });
+      return res.status(404).json({ error: "Rückgabe nicht gefunden." });
     }
     if (!grade.grade_template_id) {
-      return res.status(400).json({ error: "Tickets sind nur fuer Rueckgaben aus Pruefungen verfuegbar." });
+      return res.status(400).json({ error: "Tickets sind nur für Rückgaben aus Prüfungen verfügbar." });
     }
 
     await runAsync(
@@ -900,7 +900,7 @@ router.post("/returns/:gradeId/messages/seen", async (req, res, next) => {
 
     const gradeId = Number(req.params.gradeId);
     if (!gradeId) {
-      return res.status(400).json({ error: "Ungueltige Rueckgabe-ID." });
+      return res.status(400).json({ error: "Ungültige Rückgabe-ID." });
     }
 
     const grade = await getAsync("SELECT id FROM grades WHERE id = ? AND student_id = ?", [
@@ -908,7 +908,7 @@ router.post("/returns/:gradeId/messages/seen", async (req, res, next) => {
       context.student.id
     ]);
     if (!grade) {
-      return res.status(404).json({ error: "Rueckgabe nicht gefunden." });
+      return res.status(404).json({ error: "Rückgabe nicht gefunden." });
     }
 
     await runAsync(
@@ -1062,8 +1062,8 @@ router.get("/grades.pdf", async (req, res, next) => {
     const grades = gradeRows.map((row) => mapGradeRow(row, classInfo));
 
     const lines = [
-      "Notenuebersicht",
-      `Schueler: ${student.name}`,
+      "Notenübersicht",
+      `Schüler: ${student.name}`,
       `Klasse: ${student.class_name || classInfo?.name || ""}`,
       "",
       "Fach | Datum | Note | Gewicht | Kommentar"

--- a/school-login/routes/teacher.js
+++ b/school-login/routes/teacher.js
@@ -210,12 +210,12 @@ function validateThresholds(thresholds) {
   const t = normalizeThresholds(thresholds);
   const values = [t.grade1_min_percent, t.grade2_min_percent, t.grade3_min_percent, t.grade4_min_percent];
   if (values.some((value) => !Number.isFinite(value) || value < 0 || value > 100)) {
-    return "Grenzen muessen zwischen 0 und 100 liegen.";
+    return "Grenzen müssen zwischen 0 und 100 liegen.";
   }
   if (!(t.grade1_min_percent > t.grade2_min_percent &&
         t.grade2_min_percent > t.grade3_min_percent &&
         t.grade3_min_percent > t.grade4_min_percent)) {
-    return "Grenzen muessen streng fallend sein (1er > 2er > 3er > 4er).";
+    return "Grenzen müssen streng fallend sein (1er > 2er > 3er > 4er).";
   }
   return null;
 }
@@ -682,9 +682,9 @@ function isExcludedStudent(student) {
 }
 
 function buildExcludedStudentMessage(student, classData) {
-  const studentName = String(student?.name || "Der Schueler");
+  const studentName = String(student?.name || "Der Schüler");
   const subjectName = String(classData?.subject || "diesem Fach");
-  return `${studentName} ist im Fach ${subjectName} ausgeschlossen. Bestehende Eintraege bleiben nur historisch sichtbar und werden nicht gewertet.`;
+  return `${studentName} ist im Fach ${subjectName} ausgeschlossen. Bestehende Einträge bleiben nur historisch sichtbar und werden nicht gewertet.`;
 }
 
 async function renderAddGradeForm(req, res, payload) {
@@ -953,7 +953,7 @@ async function requireClassAccessForTeacher(req, res, classId, backUrl = "/teach
     ? await teacherCanAccessClassSubject(req.session.user.id, classId, requestedSubjectId)
     : await teacherCanAccessClass(req.session.user.id, classId);
   if (!canAccess) {
-    renderError(res, req, "Keine Berechtigung fuer diese Klasse/Fach-Zuordnung.", 403, backUrl);
+    renderError(res, req, "Keine Berechtigung für diese Klasse/Fach-Zuordnung.", 403, backUrl);
     return null;
   }
 
@@ -963,7 +963,7 @@ async function requireClassAccessForTeacher(req, res, classId, backUrl = "/teach
     hasSubjectConstraint ? requestedSubjectId : null
   );
   if (!classData) {
-    renderError(res, req, "Keine Berechtigung fuer diese Klasse/Fach-Zuordnung.", 403, backUrl);
+    renderError(res, req, "Keine Berechtigung für diese Klasse/Fach-Zuordnung.", 403, backUrl);
     return null;
   }
   req.session.teacherSubjectSelections = {
@@ -1623,7 +1623,7 @@ router.post("/create-class", async (req, res, next) => {
         status: 400,
         classes,
         formData,
-        error: "Ungueltige Klasse."
+        error: "Ungültige Klasse."
       });
     }
 
@@ -1723,7 +1723,7 @@ router.post("/delete-class/:id", async (req, res, next) => {
     const classId = Number(req.params.id);
     const subjectId = Number(req.body?.subject_id || req.query?.subject_id);
     if (!Number.isFinite(classId) || !Number.isFinite(subjectId)) {
-      return renderError(res, req, "Ungueltige Fachzuordnung.", 400, "/teacher/classes");
+      return renderError(res, req, "Ungültige Fachzuordnung.", 400, "/teacher/classes");
     }
 
     const assignments = await getTeacherAssignments(req.session.user.id);
@@ -2229,7 +2229,7 @@ router.post("/students/:classId/messages/:messageId/reply", async (req, res, nex
       return renderError(res, req, "Nachricht nicht gefunden.", 404, `/teacher/test-questions/${classId}`);
     }
     if (messageRow.student_hidden_at) {
-      return renderError(res, req, "Ticket wurde vom Schueler geschlossen.", 400, `/teacher/test-questions/${classId}`);
+      return renderError(res, req, "Ticket wurde vom Schüler geschlossen.", 400, `/teacher/test-questions/${classId}`);
     }
 
     const reply = String(req.body?.reply || "").trim();
@@ -2310,7 +2310,7 @@ router.post("/add-student/:classId", async (req, res, next) => {
         email: req.session.user.email,
         classData,
         csrfToken: req.csrfToken(),
-        error: "E-Mail nicht gefunden oder nicht als SchǬler registriert."
+        error: "E-Mail nicht gefunden oder nicht als Schüler registriert."
       });
     }
 
@@ -2320,7 +2320,7 @@ router.post("/add-student/:classId", async (req, res, next) => {
         email: req.session.user.email,
         classData,
         csrfToken: req.csrfToken(),
-        error: "Dieser SchǬler ist bereits in der Klasse."
+        error: "Dieser Schüler ist bereits in der Klasse."
       });
     }
 
@@ -2357,7 +2357,7 @@ router.post("/student-exclusion/:classId/:studentId", async (req, res, next) => 
     const students = await loadStudents(classId, req.session.user.id, classData.subject_id);
     const student = students.find((entry) => Number(entry.id) === studentId);
     if (!student) {
-      return renderError(res, req, "Schueler nicht gefunden.", 404, `/teacher/students/${classId}`);
+      return renderError(res, req, "Schüler nicht gefunden.", 404, `/teacher/students/${classId}`);
     }
 
     if (action === "include") {
@@ -2549,7 +2549,7 @@ router.post("/grades/:classId/participation", async (req, res, next) => {
       return renderError(
         res,
         req,
-        "Schueler ist in diesem Fach ausgeschlossen und kann nicht bewertet werden.",
+        "Schüler ist in diesem Fach ausgeschlossen und kann nicht bewertet werden.",
         400,
         `/teacher/grades/${classId}`
       );
@@ -2853,7 +2853,7 @@ router.get("/student-grades/:classId/:studentId/details", async (req, res, next)
 
       let includeReason = "Gewichtet in Gesamtnote.";
       if (studentExcluded) {
-        includeReason = "Nicht gewichtet (Schueler im Fach ausgeschlossen).";
+        includeReason = "Nicht gewichtet (Schüler im Fach ausgeschlossen).";
       } else if (excludedFromAverage) {
         includeReason = "Nicht gewichtet (Gewichtung entfernt).";
       } else if (skippedForAbsence) {
@@ -2914,7 +2914,7 @@ router.get("/student-grades/:classId/:studentId/details", async (req, res, next)
 
       let includeReason = "Gewichtet in Gesamtnote.";
       if (studentExcluded) {
-        includeReason = "Nicht gewichtet (Schueler im Fach ausgeschlossen).";
+        includeReason = "Nicht gewichtet (Schüler im Fach ausgeschlossen).";
       } else if (!participationEnabledForAverage) {
         includeReason = "Nicht gewichtet (MA im Profil deaktiviert oder Gewichtung 0).";
       } else if (!hasValidGrade) {
@@ -3042,7 +3042,7 @@ router.get("/student-grades/:classId/:studentId/details", async (req, res, next)
         .replace(/[^a-zA-Z0-9_-]/g, "_")
         .slice(0, 80);
 
-      pushCsv(["Sektion", "Schluessel", "Wert"]);
+      pushCsv(["Sektion", "Schlüssel", "Wert"]);
       pushCsv(["Meta", "Klasse", classData.name || ""]);
       pushCsv(["Meta", "Schüler", student.name || ""]);
       pushCsv(["Meta", "Fach", classData.subject || ""]);
@@ -3339,7 +3339,7 @@ router.post("/add-grade/:classId/:studentId", handleUpload, async (req, res, nex
     if (isExcludedStudent(student)) {
       return renderValidationError(
         400,
-        "Schueler ist in diesem Fach ausgeschlossen und kann nicht bewertet werden."
+        "Schüler ist in diesem Fach ausgeschlossen und kann nicht bewertet werden."
       );
     }
 
@@ -3352,7 +3352,7 @@ router.post("/add-grade/:classId/:studentId", handleUpload, async (req, res, nex
     }
 
     if (hasPoints && (!Number.isFinite(pointsAchievedInput.value) || pointsAchievedInput.value < 0)) {
-      return renderValidationError(400, "Erreichte Punkte muessen mindestens 0 sein.");
+      return renderValidationError(400, "Erreichte Punkte müssen mindestens 0 sein.");
     }
 
     const templateRow = await getAsync(
@@ -3376,7 +3376,7 @@ router.post("/add-grade/:classId/:studentId", handleUpload, async (req, res, nex
     if (hasPoints && templateHasMaxPoints && pointsAchievedInput.value > templateMaxPointsRaw) {
       return renderValidationError(
         400,
-        `Erreichte Punkte duerfen die maximalen Punkte (${templateMaxPointsRaw}) nicht uebersteigen.`
+        `Erreichte Punkte dürfen die maximalen Punkte (${templateMaxPointsRaw}) nicht übersteigen.`
       );
     }
 
@@ -3433,7 +3433,7 @@ router.post("/add-grade/:classId/:studentId", handleUpload, async (req, res, nex
         if (!templateHasMaxPoints) {
           return renderValidationError(
             400,
-            "Fuer 'Mit 0% werten' braucht die Prüfung maximale Punkte in der Vorlage."
+            "Für 'Mit 0% werten' braucht die Prüfung maximale Punkte in der Vorlage."
           );
         }
         resolvedPointsAchieved = 0;
@@ -3654,7 +3654,7 @@ router.get("/bulk-grade-template/:classId/:templateId", async (req, res, next) =
 
     const template = await loadTemplateForClass(classId, classData.subject_id, templateId);
     if (!template) {
-      return renderError(res, req, "Pruefung nicht gefunden.", 404, `/teacher/grade-templates/${classId}`);
+      return renderError(res, req, "Prüfung nicht gefunden.", 404, `/teacher/grade-templates/${classId}`);
     }
 
     const activeProfile = await loadActiveTeacherProfile(req.session.user.id);
@@ -3689,7 +3689,7 @@ router.get("/bulk-grade-template/:classId/:templateId", async (req, res, next) =
       messageParts.push(`${duplicates} Eintrag${duplicates === 1 ? "" : "e"} waren bereits vorhanden.`);
     }
     if (Number.isFinite(invalid) && invalid > 0) {
-      messageParts.push(`${invalid} Eingabe${invalid === 1 ? "" : "n"} wurden wegen Validierungsfehlern uebersprungen.`);
+      messageParts.push(`${invalid} Eingabe${invalid === 1 ? "" : "n"} wurden wegen Validierungsfehlern übersprungen.`);
     }
     if (hasResultQuery && messageParts.length === 0) {
       messageParts.push("Keine Bewertung gespeichert.");
@@ -3719,7 +3719,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
 
     const template = await loadTemplateForClass(classId, classData.subject_id, templateId);
     if (!template) {
-      return renderError(res, req, "Pruefung nicht gefunden.", 404, `/teacher/grade-templates/${classId}`);
+      return renderError(res, req, "Prüfung nicht gefunden.", 404, `/teacher/grade-templates/${classId}`);
     }
 
     const activeProfile = await loadActiveTeacherProfile(req.session.user.id);
@@ -3747,7 +3747,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
 
     rows.forEach((row) => {
       const studentId = row.student.id;
-      const studentName = row.student.name || `Schueler ${studentId}`;
+      const studentName = row.student.name || `Schüler ${studentId}`;
       const noteText = String(row.form.note || "").trim();
       const gradeInput = parseOptionalNumber(row.form.grade);
       const pointsInput = parseOptionalNumber(row.form.points_achieved);
@@ -3758,7 +3758,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
       if (!touched) return;
 
       if (isExcludedStudent(row.student)) {
-        validationErrors.push(`${studentName}: Schueler ist in diesem Fach ausgeschlossen.`);
+        validationErrors.push(`${studentName}: Schüler ist in diesem Fach ausgeschlossen.`);
         return;
       }
 
@@ -3768,20 +3768,20 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
       }
 
       if (hasPoints && (!Number.isFinite(pointsInput.value) || pointsInput.value < 0)) {
-        validationErrors.push(`${studentName}: Erreichte Punkte muessen mindestens 0 sein.`);
+        validationErrors.push(`${studentName}: Erreichte Punkte müssen mindestens 0 sein.`);
         return;
       }
 
       if (hasPoints && !templateHasMaxPoints) {
         validationErrors.push(
-          `${studentName}: Diese Pruefung hat keine maximalen Punkte in der Vorlage.`
+          `${studentName}: Diese Prüfung hat keine maximalen Punkte in der Vorlage.`
         );
         return;
       }
 
       if (hasPoints && templateHasMaxPoints && pointsInput.value > templateMaxPointsRaw) {
         validationErrors.push(
-          `${studentName}: Erreichte Punkte duerfen ${templateMaxPointsRaw} nicht uebersteigen.`
+          `${studentName}: Erreichte Punkte dürfen ${templateMaxPointsRaw} nicht übersteigen.`
         );
         return;
       }
@@ -3821,7 +3821,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
         if (absenceMode === ABSENCE_MODE_INCLUDE_ZERO) {
           if (!templateHasMaxPoints) {
             validationErrors.push(
-              `${studentName}: Fuer Abwesenheit mit 0% braucht die Vorlage maximale Punkte.`
+              `${studentName}: Für Abwesenheit mit 0% braucht die Vorlage maximale Punkte.`
             );
             return;
           }
@@ -3865,7 +3865,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
         existingGradesByStudent,
         activeProfile,
         formData: req.body || {},
-        error: "Einige Eingaben sind ungueltig. Bitte pruefen.",
+        error: "Einige Eingaben sind ungültig. Bitte prüfen.",
         validationErrors
       });
     }
@@ -3888,7 +3888,7 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
     const classSchoolYearId = Number(classData.school_year_id);
 
     if (!Number.isFinite(classSchoolYearId)) {
-      throw new Error(`Klasse ${classId} hat kein gueltiges school_year_id.`);
+      throw new Error(`Klasse ${classId} hat kein gültiges school_year_id.`);
     }
 
     for (const row of preparedRows) {
@@ -4041,7 +4041,7 @@ router.post("/create-template/:classId", async (req, res, next) => {
         categoryDefinitions: TEMPLATE_CATEGORY_DEFINITIONS,
         formData,
         csrfToken: req.csrfToken(),
-        error: "Fuer diese Kategorie ist im aktiven Profil keine gespeicherte Gewichtung vorhanden."
+        error: "Für diese Kategorie ist im aktiven Profil keine gespeicherte Gewichtung vorhanden."
       });
     }
     if (weightValue < 0) {
@@ -4063,7 +4063,7 @@ router.post("/create-template/:classId", async (req, res, next) => {
         categoryDefinitions: TEMPLATE_CATEGORY_DEFINITIONS,
         formData,
         csrfToken: req.csrfToken(),
-        error: "Maximale Punkte muessen groesser als 0 sein."
+        error: "Maximale Punkte müssen größer als 0 sein."
       });
     }
 
@@ -4198,7 +4198,7 @@ router.post("/edit-template/:classId/:templateId", async (req, res, next) => {
         templateId,
         formData,
         csrfToken: req.csrfToken(),
-        error: "Fuer diese Kategorie ist im aktiven Profil keine gespeicherte Gewichtung vorhanden."
+        error: "Für diese Kategorie ist im aktiven Profil keine gespeicherte Gewichtung vorhanden."
       });
     }
     if (weightValue < 0) {
@@ -4222,7 +4222,7 @@ router.post("/edit-template/:classId/:templateId", async (req, res, next) => {
         templateId,
         formData,
         csrfToken: req.csrfToken(),
-        error: "Maximale Punkte muessen groesser als 0 sein."
+        error: "Maximale Punkte müssen größer als 0 sein."
       });
     }
 
@@ -4472,7 +4472,7 @@ router.post("/special-assessments/:classId", async (req, res, next) => {
           weight,
           grade
         },
-        error: "Schueler ist in diesem Fach ausgeschlossen und kann nicht bewertet werden.",
+        error: "Schüler ist in diesem Fach ausgeschlossen und kann nicht bewertet werden.",
         csrfToken: req.csrfToken()
       });
     }

--- a/school-login/server.test.js
+++ b/school-login/server.test.js
@@ -309,7 +309,7 @@ test("student and teacher can complete the full grade message workflow", async (
 
   const teacherCsrf = await fetchCsrfToken("/teacher/test-questions/1", teacherLogin.cookies);
   const messageId = studentThread.messages[0].id;
-  const replyText = "Teilaufgabe 3 war unvollstaendig, deshalb wurden Punkte abgezogen.";
+  const replyText = "Teilaufgabe 3 war unvollständig, deshalb wurden Punkte abgezogen.";
   const replyParams = new URLSearchParams({
     _csrf: teacherCsrf,
     reply: replyText
@@ -467,7 +467,7 @@ test("admin archive renders the optimized overview and exports CSV", async () =>
 
   const archivePage = await fetchWithCookies("/archive", {}, loginResult.cookies);
   assert.strictEqual(archivePage.response.status, 200);
-  assert.match(archivePage.body, /Historische Schuljahre fuer viel Datenvolumen aufbereitet/);
+  assert.match(archivePage.body, /Historische Schuljahre für viel Datenvolumen aufbereitet/);
   assert.match(archivePage.body, /CSV Noten/);
 
   const csvResponse = await fetchWithCookies(
@@ -478,7 +478,7 @@ test("admin archive renders the optimized overview and exports CSV", async () =>
   assert.strictEqual(csvResponse.response.status, 200);
   assert.match(csvResponse.response.headers.get("content-type") || "", /text\/csv/);
   assert.match(csvResponse.response.headers.get("content-disposition") || "", /archiv-.*-noten\.csv/);
-  assert.match(csvResponse.body, /"Schueler"/);
+  assert.match(csvResponse.body, /"Schüler"/);
   assert.match(csvResponse.body, /"Kommentar"/);
 });
 

--- a/school-login/services/rolloverService.js
+++ b/school-login/services/rolloverService.js
@@ -114,7 +114,7 @@ function normalizeSqlDateInput(value, fieldLabel) {
 
   const sqlDate = toSqlDate(normalizedValue);
   if (!sqlDate || !getDateParts(sqlDate)) {
-    throw new Error(`${fieldLabel} ist ungueltig.`);
+    throw new Error(`${fieldLabel} ist ungültig.`);
   }
 
   return sqlDate;
@@ -203,7 +203,7 @@ function parseStudentImportLine(line) {
 
   email = normalizeText(email);
   if (!email || !email.includes("@")) {
-    return { error: "E-Mail fehlt oder ist ungueltig." };
+    return { error: "E-Mail fehlt oder ist ungültig." };
   }
 
   if (!name) {
@@ -807,7 +807,7 @@ function validateWizardDraft(draft) {
     const expectedStudentCount = Array.isArray(classRow.students) ? classRow.students.length : 0;
     const plannedStudentCount = studentCountsBySourceClassId.get(Number(classRow.id)) || 0;
     if (plannedStudentCount !== expectedStudentCount) {
-      errors.push(`Schuelerplanung fuer ${formatClassSubjectLabel(classRow)} ist unvollstaendig.`);
+      errors.push(`Schülerplanung für ${formatClassSubjectLabel(classRow)} ist unvollständig.`);
     }
   });
 
@@ -966,7 +966,7 @@ async function createArchiveEntries({ schoolYearId, summary, queryRunner }) {
 function buildExecutionRows(draft) {
   const validation = validateWizardDraft(draft);
   if (!validation.valid) {
-    throw new Error(validation.errors[0] || "Wizard-Entwurf ist ungueltig.");
+    throw new Error(validation.errors[0] || "Wizard-Entwurf ist ungültig.");
   }
 
   const enabledPlans = getEnabledTargetPlans(draft);
@@ -1161,7 +1161,7 @@ async function executeWizardRollover({ draft, executedBy, confirmationText }) {
     endDate: restoredDraft.nextSchoolYear?.endDate
   });
   if (Number(liveSource.activeSchoolYear.id) !== Number(restoredDraft.activeSchoolYear.id)) {
-    throw new Error("Das aktive Schuljahr hat sich geaendert. Assistent bitte neu starten.");
+    throw new Error("Das aktive Schuljahr hat sich geändert. Assistent bitte neu starten.");
   }
   if (liveSource.nextSchoolYearExists) {
     throw new Error(`Das Schuljahr ${liveSource.nextSchoolYear.name} existiert bereits.`);
@@ -1169,7 +1169,7 @@ async function executeWizardRollover({ draft, executedBy, confirmationText }) {
 
   const normalizedConfirmation = normalizeText(confirmationText);
   if (normalizedConfirmation !== restoredDraft.nextSchoolYear.name) {
-    throw new Error(`Bestaetigung fehlt. Bitte ${restoredDraft.nextSchoolYear.name} exakt eingeben.`);
+    throw new Error(`Bestätigung fehlt. Bitte ${restoredDraft.nextSchoolYear.name} exakt eingeben.`);
   }
 
   const executionRows = buildExecutionRows(restoredDraft);
@@ -1223,7 +1223,7 @@ function ensureBackupPathInDirectory(filePath) {
     resolvedPath === resolvedBackupDir || resolvedPath.startsWith(`${resolvedBackupDir}${path.sep}`);
 
   if (!isInsideBackupDir) {
-    throw new Error("Backup-Pfad ist ungueltig.");
+    throw new Error("Backup-Pfad ist ungültig.");
   }
 
   return resolvedPath;
@@ -1245,7 +1245,7 @@ async function readBackupSnapshot(backupPath) {
   const previousSchoolYearName = normalizeText(payload?.meta?.activeSchoolYear?.name);
   const targetSchoolYearName = normalizeText(payload?.meta?.nextSchoolYear?.name);
   if (!previousSchoolYearName || !targetSchoolYearName) {
-    throw new Error("Backup-Datei ist unvollstaendig.");
+    throw new Error("Backup-Datei ist unvollständig.");
   }
 
   return {
@@ -1336,7 +1336,7 @@ async function restoreSchoolYearFromBackup({ backupPath, executedBy }) {
   }
 
   if (normalizeText(currentActiveSchoolYear?.name) !== targetSchoolYearName) {
-    throw new Error(`Wiederherstellen ist nur moeglich, wenn ${targetSchoolYearName} aktuell aktiv ist.`);
+    throw new Error(`Wiederherstellen ist nur möglich, wenn ${targetSchoolYearName} aktuell aktiv ist.`);
   }
 
   if (!previousSchoolYear) {

--- a/school-login/views/admin/add-student.ejs
+++ b/school-login/views/admin/add-student.ejs
@@ -4,7 +4,7 @@
   const bulkValues = bulkForm || {};
   const hasBulkResult = Boolean(bulkResult);
   const page = {
-    title: 'Admin - Schueler hinzufuegen',
+    title: 'Admin - Schüler hinzufügen',
     headerTitle: 'Adminbereich',
     styles: ['/css/admin.css'],
     scripts: ['/js/app.js'],
@@ -19,21 +19,21 @@
         <div class="app-main-header admin-create-header">
           <div>
             <p class="app-main-subtitle">Klasse <%= classData.name %></p>
-            <h1>Schueler hinzufuegen</h1>
-            <p class="admin-muted admin-create-copy">Nur vorhandene Student-Konten koennen der Klasse zugeordnet werden. Wechsle zwischen Einzelzuordnung und Bulk-Modus.</p>
+            <h1>Schüler hinzufügen</h1>
+            <p class="admin-muted admin-create-copy">Nur vorhandene Student-Konten können der Klasse zugeordnet werden. Wechsle zwischen Einzelzuordnung und Bulk-Modus.</p>
           </div>
-          <a class="btn btn-secondary" href="/admin/classes/<%= classData.id %>/students">Zurueck</a>
+          <a class="btn btn-secondary" href="/admin/classes/<%= classData.id %>/students">Zurück</a>
         </div>
 
         <div class="admin-create-shell" data-create-switcher data-default-mode="<%= resolvedMode %>">
           <div class="admin-create-overview">
             <div class="admin-create-overview-card">
               <strong>Einzeln</strong>
-              <span>Geeignet fuer neue Eintritte oder gezielte Korrekturen einzelner Zuordnungen.</span>
+              <span>Geeignet für neue Eintritte oder gezielte Korrekturen einzelner Zuordnungen.</span>
             </div>
             <div class="admin-create-overview-card">
               <strong>Bulk</strong>
-              <span>Mehrere registrierte Schueler per E-Mail-Liste in einem Schritt der Klasse zuweisen.</span>
+              <span>Mehrere registrierte Schüler per E-Mail-Liste in einem Schritt der Klasse zuweisen.</span>
             </div>
           </div>
 
@@ -52,7 +52,7 @@
               <div class="admin-panel-card">
                 <div class="admin-panel-head">
                   <div>
-                    <h3>Einzelnen Schueler zuordnen</h3>
+                    <h3>Einzelnen Schüler zuordnen</h3>
                     <p class="admin-muted">Der Name kann automatisch aus `vorname.nachname@...` abgeleitet werden.</p>
                   </div>
                 </div>
@@ -76,7 +76,7 @@
                   </div>
 
                   <div class="admin-panel-actions">
-                    <button class="btn btn-primary" type="submit">Schueler zuordnen</button>
+                    <button class="btn btn-primary" type="submit">Schüler zuordnen</button>
                   </div>
                 </form>
               </div>
@@ -87,7 +87,7 @@
                 <div class="admin-panel-head">
                   <div>
                     <h3>Bulk-Zuordnung</h3>
-                    <p class="admin-muted">Eine registrierte Schueler-E-Mail pro Zeile. Der Name wird aus der Adresse abgeleitet.</p>
+                    <p class="admin-muted">Eine registrierte Schüler-E-Mail pro Zeile. Der Name wird aus der Adresse abgeleitet.</p>
                   </div>
                 </div>
 
@@ -146,7 +146,7 @@
                           <% }); %>
                         </ul>
                       <% } else { %>
-                        <p class="admin-muted">Keine fehlgeschlagenen Eintraege.</p>
+                        <p class="admin-muted">Keine fehlgeschlagenen Einträge.</p>
                       <% } %>
                     </div>
                   </div>

--- a/school-login/views/admin/archive.ejs
+++ b/school-login/views/admin/archive.ejs
@@ -37,9 +37,9 @@
     : null;
   const selectedYearLabel = selectedSchoolYear
     ? formatDateRange(selectedSchoolYear.start_date, selectedSchoolYear.end_date)
-    : 'Kein Schuljahr ausgewaehlt';
+    : 'Kein Schuljahr ausgewählt';
   const jumpLinks = [
-    { href: '#archive-overview', label: 'Uebersicht', count: archiveStats?.totalRecords || 0 },
+    { href: '#archive-overview', label: 'Übersicht', count: archiveStats?.totalRecords || 0 },
     { href: '#archive-log', label: 'Archivstatus', count: archiveEntries.length },
     { href: '#archive-classes', label: 'Klassen', count: classes.length },
     { href: '#archive-assignments', label: 'Zuordnungen', count: assignments.length },
@@ -91,7 +91,7 @@
               <dd><%= selectedYearLabel %></dd>
             </div>
             <div class="archive-meta-item">
-              <dt>Datensaetze</dt>
+              <dt>Datensätze</dt>
               <dd><%= formatNumber(totalRecords) %></dd>
             </div>
             <div class="archive-meta-item">
@@ -99,11 +99,11 @@
               <dd><%= formatAverageGrade(archiveStats?.averageGrade) %></dd>
             </div>
             <div class="archive-meta-item">
-              <dt>Schueler</dt>
+              <dt>Schüler</dt>
               <dd><%= formatNumber(archiveStats?.uniqueStudents || 0) %></dd>
             </div>
             <div class="archive-meta-item">
-              <dt>Lehrkraefte</dt>
+              <dt>Lehrkräfte</dt>
               <dd><%= formatNumber(archiveStats?.uniqueTeachers || 0) %></dd>
             </div>
             <div class="archive-meta-item">
@@ -111,7 +111,7 @@
               <dd><%= formatNumber(archiveStats?.archiveTypes || 0) %></dd>
             </div>
             <div class="archive-meta-item">
-              <dt>Letzte Aktivitaet</dt>
+              <dt>Letzte Aktivität</dt>
               <dd><%= formatDateTime(archiveStats?.latestActivityAt) %></dd>
             </div>
           </dl>
@@ -198,7 +198,7 @@
               <h2>Archivstatus</h2>
             </div>
             <div class="archive-section-actions">
-              <span class="admin-badge"><%= formatNumber(archiveEntries.length) %> Eintraege</span>
+              <span class="admin-badge"><%= formatNumber(archiveEntries.length) %> Einträge</span>
               <% if (buildExportUrl('archives')) { %>
                 <a class="btn btn-secondary" href="<%= buildExportUrl('archives') %>">CSV herunterladen</a>
               <% } %>
@@ -206,7 +206,7 @@
           </div>
 
           <% if (!archiveEntries.length) { %>
-            <div class="admin-empty">Fuer dieses Schuljahr wurden noch keine Archiv-Eintraege protokolliert.</div>
+            <div class="admin-empty">Für dieses Schuljahr wurden noch keine Archiv-Einträge protokolliert.</div>
           <% } else { %>
             <div class="archive-section-tools">
               <label class="archive-search-field">
@@ -241,13 +241,13 @@
                   </tbody>
                 </table>
               </div>
-              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Eintraege fuer den aktuellen Filter gefunden.</div>
+              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Einträge für den aktuellen Filter gefunden.</div>
               <div class="archive-table-footer">
                 <span class="archive-table-summary" data-archive-summary>Alle <%= formatNumber(archiveEntries.length) %> Zeilen geladen.</span>
                 <div class="archive-table-actions" data-archive-actions hidden>
                   <button class="btn btn-secondary" type="button" data-archive-more hidden>Mehr laden</button>
                   <button class="btn btn-secondary" type="button" data-archive-all hidden>Alle zeigen</button>
-                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zuruecksetzen</button>
+                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zurücksetzen</button>
                 </div>
               </div>
             </div>
@@ -269,7 +269,7 @@
           </div>
 
           <% if (!classes.length) { %>
-            <div class="admin-empty">Keine Klassen fuer dieses Schuljahr gefunden.</div>
+            <div class="admin-empty">Keine Klassen für dieses Schuljahr gefunden.</div>
           <% } else { %>
             <div class="archive-section-tools">
               <label class="archive-search-field">
@@ -277,7 +277,7 @@
                 <input type="search" placeholder="Nach Klasse, Fach oder Datum filtern" data-archive-search>
               </label>
               <div class="archive-inline-stats">
-                <span class="archive-inline-stat"><%= formatNumber(classes.length) %> Datensaetze</span>
+                <span class="archive-inline-stat"><%= formatNumber(classes.length) %> Datensätze</span>
                 <span class="archive-inline-stat">CSV komplett</span>
               </div>
             </div>
@@ -307,13 +307,13 @@
                   </tbody>
                 </table>
               </div>
-              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Klassen fuer den aktuellen Filter gefunden.</div>
+              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Klassen für den aktuellen Filter gefunden.</div>
               <div class="archive-table-footer">
                 <span class="archive-table-summary" data-archive-summary>Alle <%= formatNumber(classes.length) %> Zeilen geladen.</span>
                 <div class="archive-table-actions" data-archive-actions hidden>
                   <button class="btn btn-secondary" type="button" data-archive-more hidden>Mehr laden</button>
                   <button class="btn btn-secondary" type="button" data-archive-all hidden>Alle zeigen</button>
-                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zuruecksetzen</button>
+                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zurücksetzen</button>
                 </div>
               </div>
             </div>
@@ -335,7 +335,7 @@
           </div>
 
           <% if (!assignments.length) { %>
-            <div class="admin-empty">Keine Zuordnungen fuer dieses Schuljahr gefunden.</div>
+            <div class="admin-empty">Keine Zuordnungen für dieses Schuljahr gefunden.</div>
           <% } else { %>
             <div class="archive-section-tools">
               <label class="archive-search-field">
@@ -343,7 +343,7 @@
                 <input type="search" placeholder="Nach Klasse, Fach oder Lehrkraft filtern" data-archive-search>
               </label>
               <div class="archive-inline-stats">
-                <span class="archive-inline-stat"><%= formatNumber(archiveStats?.uniqueTeachers || 0) %> Lehrkraefte beteiligt</span>
+                <span class="archive-inline-stat"><%= formatNumber(archiveStats?.uniqueTeachers || 0) %> Lehrkräfte beteiligt</span>
                 <span class="archive-inline-stat">CSV komplett</span>
               </div>
             </div>
@@ -355,7 +355,7 @@
                     <tr>
                       <th>Klasse</th>
                       <th>Fach</th>
-                      <th>Lehrkraefte</th>
+                      <th>Lehrkräfte</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -369,13 +369,13 @@
                   </tbody>
                 </table>
               </div>
-              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Zuordnungen fuer den aktuellen Filter gefunden.</div>
+              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Zuordnungen für den aktuellen Filter gefunden.</div>
               <div class="archive-table-footer">
                 <span class="archive-table-summary" data-archive-summary>Alle <%= formatNumber(assignments.length) %> Zeilen geladen.</span>
                 <div class="archive-table-actions" data-archive-actions hidden>
                   <button class="btn btn-secondary" type="button" data-archive-more hidden>Mehr laden</button>
                   <button class="btn btn-secondary" type="button" data-archive-all hidden>Alle zeigen</button>
-                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zuruecksetzen</button>
+                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zurücksetzen</button>
                 </div>
               </div>
             </div>
@@ -397,15 +397,15 @@
           </div>
 
           <% if (!grades.length) { %>
-            <div class="admin-empty">Keine Noten fuer dieses Schuljahr gefunden.</div>
+            <div class="admin-empty">Keine Noten für dieses Schuljahr gefunden.</div>
           <% } else { %>
             <div class="archive-section-tools archive-section-tools-wide">
               <label class="archive-search-field">
                 <span>Noten durchsuchen</span>
-                <input type="search" placeholder="Nach Klasse, Schueler, Fach, Note oder Kommentar filtern" data-archive-search>
+                <input type="search" placeholder="Nach Klasse, Schüler, Fach, Note oder Kommentar filtern" data-archive-search>
               </label>
               <div class="archive-inline-stats">
-                <span class="archive-inline-stat"><%= formatNumber(archiveStats?.uniqueStudents || 0) %> Schueler</span>
+                <span class="archive-inline-stat"><%= formatNumber(archiveStats?.uniqueStudents || 0) %> Schüler</span>
                 <span class="archive-inline-stat">Durchschnitt: <%= formatAverageGrade(archiveStats?.averageGrade) %></span>
                 <span class="archive-inline-stat">CSV: <%= formatNumber(totalGrades) %> Noten</span>
               </div>
@@ -417,7 +417,7 @@
                   <thead>
                     <tr>
                       <th>Klasse</th>
-                      <th>Schueler</th>
+                      <th>Schüler</th>
                       <th>Fach</th>
                       <th>Note</th>
                       <th>Kommentar</th>
@@ -442,13 +442,13 @@
                   </tbody>
                 </table>
               </div>
-              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Noten fuer den aktuellen Filter gefunden.</div>
+              <div class="archive-filter-empty" data-archive-filter-empty hidden>Keine Noten für den aktuellen Filter gefunden.</div>
               <div class="archive-table-footer">
                 <span class="archive-table-summary" data-archive-summary>Alle <%= formatNumber(totalGrades) %> Zeilen geladen.</span>
                 <div class="archive-table-actions" data-archive-actions hidden>
                   <button class="btn btn-secondary" type="button" data-archive-more hidden>Mehr laden</button>
                   <button class="btn btn-secondary" type="button" data-archive-all hidden>Alle zeigen</button>
-                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zuruecksetzen</button>
+                  <button class="btn btn-secondary" type="button" data-archive-reset hidden>Zurücksetzen</button>
                 </div>
               </div>
             </div>

--- a/school-login/views/admin/assignments/index.ejs
+++ b/school-login/views/admin/assignments/index.ejs
@@ -30,7 +30,7 @@
         <div class="admin-card">
           <div class="admin-topbar">
             <div>
-              <p class="admin-eyebrow">Uebersicht</p>
+              <p class="admin-eyebrow">Übersicht</p>
               <h3>Aktive Zuordnungen</h3>
             </div>
             <span class="admin-badge"><%= assignments.length %> Gruppen</span>

--- a/school-login/views/admin/assignments/new.ejs
+++ b/school-login/views/admin/assignments/new.ejs
@@ -23,9 +23,9 @@
           <div>
             <p class="app-main-subtitle">Unterrichtszuordnungen</p>
             <h1>Lehrer einem Klassenfach zuordnen</h1>
-            <p class="admin-muted">Klassen koennen ohne Fach starten. Hier wird das Fach pro Zuordnung festgelegt.</p>
+            <p class="admin-muted">Klassen können ohne Fach starten. Hier wird das Fach pro Zuordnung festgelegt.</p>
           </div>
-          <a class="btn btn-secondary" href="/admin/assignments">Zur Uebersicht</a>
+          <a class="btn btn-secondary" href="/admin/assignments">Zur Übersicht</a>
         </div>
 
         <% if (message) { %>
@@ -45,7 +45,7 @@
               </select>
               <input type="hidden" name="create_subject" value="1">
               <button class="btn btn-secondary" type="submit">Klasse laden</button>
-              <a class="btn" href="/admin/assignments/new?class=<%= encodeURIComponent(selClassId) %>">Bestehendes Fach waehlen</a>
+              <a class="btn" href="/admin/assignments/new?class=<%= encodeURIComponent(selClassId) %>">Bestehendes Fach wählen</a>
             </form>
           <% } else { %>
             <form class="admin-form" method="GET" action="/admin/assignments/new">
@@ -66,7 +66,7 @@
           <% if (!classes.length) { %>
             <p class="admin-muted">Es gibt noch keine Klassen im aktiven Schuljahr.</p>
           <% } else if (!subjects.length) { %>
-            <p class="admin-muted">Es gibt noch keine Faecher. Lege unten ein neues Fach an und ordne es direkt Lehrern zu.</p>
+            <p class="admin-muted">Es gibt noch keine Fächer. Lege unten ein neues Fach an und ordne es direkt Lehrern zu.</p>
           <% } %>
         </div>
 
@@ -95,13 +95,13 @@
                   placeholder="z.B. Mathematik"
                   required
                 >
-                <p class="admin-muted">Dieses Fach wird angelegt und direkt der gewaehlten Klasse mit den markierten Lehrern zugeordnet.</p>
+                <p class="admin-muted">Dieses Fach wird angelegt und direkt der gewählten Klasse mit den markierten Lehrern zugeordnet.</p>
               <% } else { %>
                 <input type="hidden" name="subject_id" value="<%= selSubjectId %>">
               <% } %>
 
               <div class="assign-teacher-section">
-                <label>Lehrer auswaehlen</label>
+                <label>Lehrer auswählen</label>
                 <input
                   type="text"
                   id="teacher-search"
@@ -129,7 +129,7 @@
                 </div>
 
                 <div id="available-section" class="assign-group">
-                  <p class="assign-group-title">Verfuegbare Lehrer (<span id="available-count"><%= teachers.filter((t) => !assignedSet.has(t.id)).length %></span>)</p>
+                  <p class="assign-group-title">Verfügbare Lehrer (<span id="available-count"><%= teachers.filter((t) => !assignedSet.has(t.id)).length %></span>)</p>
                   <div class="assign-new-table-wrap">
                     <table class="assign-new-table" id="available-list">
                       <thead><tr><th class="assign-col-check"></th><th>Name</th><th>E-Mail</th></tr></thead>
@@ -196,7 +196,7 @@
 
         function updateSelectionCount() {
           var checked = document.querySelectorAll('#available-list input[type="checkbox"]:checked');
-          selectionCount.textContent = checked.length ? checked.length + ' Lehrer ausgewaehlt' : '';
+          selectionCount.textContent = checked.length ? checked.length + ' Lehrer ausgewählt' : '';
         }
 
         searchInput.addEventListener('input', filterTeachers);

--- a/school-login/views/admin/audit-logs.ejs
+++ b/school-login/views/admin/audit-logs.ejs
@@ -43,7 +43,7 @@
             <h1>Audit-Log</h1>
           </div>
           <div class="admin-audit-hero-actions">
-            <a class="btn btn-secondary" href="<%= returnTo %>">Zurueck</a>
+            <a class="btn btn-secondary" href="<%= returnTo %>">Zurück</a>
           </div>
         </div>
       </div>
@@ -52,7 +52,7 @@
         <div class="admin-topbar">
           <div>
             <p class="admin-eyebrow">Filter</p>
-            <h3>Eintraege suchen</h3>
+            <h3>Einträge suchen</h3>
           </div>
         </div>
         <% if (filterError) { %>
@@ -83,7 +83,7 @@
               <input type="text" name="route" placeholder="/teacher/add-grade" value="<%= search.route || '' %>">
             </label>
             <label class="admin-audit-filter-field">
-              <span>Entitaet</span>
+              <span>Entität</span>
               <input type="text" name="entity" placeholder="user, class, grade" value="<%= search.entity || '' %>">
             </label>
             <label class="admin-audit-filter-field">
@@ -101,7 +101,7 @@
           </div>
           <div class="admin-audit-filter-actions">
             <button class="btn btn-secondary" type="submit">Suchen</button>
-            <a class="btn" href="<%= resetHref %>">Zuruecksetzen</a>
+            <a class="btn" href="<%= resetHref %>">Zurücksetzen</a>
           </div>
         </form>
       </div>
@@ -113,14 +113,14 @@
             <h3 class="admin-heading-spaced"><%= activeCategoryLabel || 'Hauptlog' %></h3>
             <p class="admin-muted">
               <% if (hasLogs) { %>
-                Zeige <strong><%= pageState.rangeStart %></strong> bis <strong><%= pageState.rangeEnd %></strong> von <strong><%= Number(totalCount || 0) %></strong> Eintraegen.
+                Zeige <strong><%= pageState.rangeStart %></strong> bis <strong><%= pageState.rangeEnd %></strong> von <strong><%= Number(totalCount || 0) %></strong> Einträgen.
               <% } else { %>
-                Keine Audit-Eintraege gefunden.
+                Keine Audit-Einträge gefunden.
               <% } %>
             </p>
           </div>
           <div class="admin-audit-summary">
-            <span class="admin-badge"><%= Number(totalCount || 0) %> Eintraege</span>
+            <span class="admin-badge"><%= Number(totalCount || 0) %> Einträge</span>
             <span class="admin-badge admin-badge-neutral">Seite <%= pageState.currentPage %> / <%= pageState.totalPages %></span>
             <span class="admin-badge admin-badge-neutral">Max. <%= pageState.maxPageSize %> pro Seite</span>
           </div>
@@ -141,7 +141,7 @@
           <nav class="admin-pagination" aria-label="Audit-Log Seiten oben">
             <div class="admin-pagination-group">
               <a class="btn <%= pageState.hasPrev ? '' : 'is-disabled' %>" href="<%= pageState.hasPrev ? pageState.firstHref : '#' %>">Erste</a>
-              <a class="btn <%= pageState.hasPrev ? '' : 'is-disabled' %>" href="<%= pageState.hasPrev ? pageState.prevHref : '#' %>">Zurueck</a>
+              <a class="btn <%= pageState.hasPrev ? '' : 'is-disabled' %>" href="<%= pageState.hasPrev ? pageState.prevHref : '#' %>">Zurück</a>
             </div>
             <div class="admin-pagination-pages">
               <% pageState.pages.forEach(function (pageLink) { %>
@@ -164,7 +164,7 @@
                 <th>Akteur</th>
                 <th>Bereich</th>
                 <th>Aktion</th>
-                <th>Ziel / Entitaet</th>
+                <th>Ziel / Entität</th>
                 <th>Details / Eingaben</th>
                 <th>Parameter / Filter</th>
                 <th>Request / Client</th>
@@ -173,7 +173,7 @@
             <tbody>
               <% if (!hasLogs) { %>
                 <tr>
-                  <td colspan="9" class="admin-muted">Keine Audit-Eintraege gefunden.</td>
+                  <td colspan="9" class="admin-muted">Keine Audit-Einträge gefunden.</td>
                 </tr>
               <% } %>
               <% logs.forEach(function(entry){ %>
@@ -226,7 +226,7 @@
           <nav class="admin-pagination admin-pagination-bottom" aria-label="Audit-Log Seiten unten">
             <div class="admin-pagination-group">
               <a class="btn <%= pageState.hasPrev ? '' : 'is-disabled' %>" href="<%= pageState.hasPrev ? pageState.firstHref : '#' %>">Erste</a>
-              <a class="btn <%= pageState.hasPrev ? '' : 'is-disabled' %>" href="<%= pageState.hasPrev ? pageState.prevHref : '#' %>">Zurueck</a>
+              <a class="btn <%= pageState.hasPrev ? '' : 'is-disabled' %>" href="<%= pageState.hasPrev ? pageState.prevHref : '#' %>">Zurück</a>
             </div>
             <div class="admin-pagination-pages">
               <% pageState.pages.forEach(function (pageLink) { %>

--- a/school-login/views/admin/class-detail.ejs
+++ b/school-login/views/admin/class-detail.ejs
@@ -22,10 +22,10 @@
             </p>
           </div>
           <div class="admin-actions-row">
-            <a class="btn btn-primary" href="/admin/classes/<%= classData.id %>/students">Schueler</a>
+            <a class="btn btn-primary" href="/admin/classes/<%= classData.id %>/students">Schüler</a>
             <a class="btn btn-secondary" href="/admin/assignments/new?class=<%= classData.id %>&create_subject=1">Fach erstellen</a>
             <a class="btn btn-secondary" href="/admin/classes/<%= classData.id %>/edit">Bearbeiten</a>
-            <a class="btn" href="/admin/classes">Zurueck</a>
+            <a class="btn" href="/admin/classes">Zurück</a>
           </div>
         </div>
 
@@ -35,11 +35,11 @@
             <strong><%= stats.teacher_count %></strong>
           </div>
           <div class="admin-stat-card">
-            <p class="admin-eyebrow">Schueler</p>
+            <p class="admin-eyebrow">Schüler</p>
             <strong><%= stats.student_count %></strong>
           </div>
           <div class="admin-stat-card">
-            <p class="admin-eyebrow">Faecher</p>
+            <p class="admin-eyebrow">Fächer</p>
             <strong><%= stats.subject_count %></strong>
           </div>
         </div>
@@ -49,12 +49,12 @@
             <div class="admin-topbar">
               <div>
                 <p class="admin-eyebrow">Lehrer</p>
-                <h3>Lehreruebersicht</h3>
+                <h3>Lehrerübersicht</h3>
               </div>
-              <span class="admin-badge"><%= teacherRows.length %> Eintraege</span>
+              <span class="admin-badge"><%= teacherRows.length %> Einträge</span>
             </div>
             <% if (!teacherRows.length) { %>
-              <div class="admin-empty">Noch keine Lehrer ueber Faecher zugeordnet.</div>
+              <div class="admin-empty">Noch keine Lehrer über Fächer zugeordnet.</div>
             <% } else { %>
               <div class="admin-table-wrap">
                 <table class="admin-table">
@@ -62,7 +62,7 @@
                     <tr>
                       <th>Name</th>
                       <th>E-Mail</th>
-                      <th>Faecher</th>
+                      <th>Fächer</th>
                       <th>Anzahl</th>
                     </tr>
                   </thead>
@@ -89,13 +89,13 @@
           <div class="admin-card">
             <div class="admin-topbar">
               <div>
-                <p class="admin-eyebrow">Schueler</p>
-                <h3>Schuelerliste</h3>
+                <p class="admin-eyebrow">Schüler</p>
+                <h3>Schülerliste</h3>
               </div>
-              <span class="admin-badge"><%= students.length %> Eintraege</span>
+              <span class="admin-badge"><%= students.length %> Einträge</span>
             </div>
             <% if (!students.length) { %>
-              <div class="admin-empty">Noch keine Schueler in dieser Klasse.</div>
+              <div class="admin-empty">Noch keine Schüler in dieser Klasse.</div>
             <% } else { %>
               <div class="admin-table-wrap">
                 <table class="admin-table">
@@ -121,13 +121,13 @@
           <div class="admin-card">
             <div class="admin-topbar">
               <div>
-                <p class="admin-eyebrow">Faecher</p>
-                <h3>Fachuebersicht</h3>
+                <p class="admin-eyebrow">Fächer</p>
+                <h3>Fachübersicht</h3>
               </div>
-              <span class="admin-badge"><%= subjectRows.length %> Eintraege</span>
+              <span class="admin-badge"><%= subjectRows.length %> Einträge</span>
             </div>
             <% if (!subjectRows.length) { %>
-              <div class="admin-empty">Noch keine Faecher zugeordnet.</div>
+              <div class="admin-empty">Noch keine Fächer zugeordnet.</div>
             <% } else { %>
               <div class="admin-table-wrap">
                 <table class="admin-table">

--- a/school-login/views/admin/class-students.ejs
+++ b/school-login/views/admin/class-students.ejs
@@ -1,7 +1,7 @@
 <%
   const search = query || {};
   const page = {
-    title: `Admin - Schueler (${classData.name})`,
+    title: `Admin - Schüler (${classData.name})`,
     headerTitle: 'Adminbereich',
     styles: ['/css/admin.css'],
     scripts: ['/js/app.js'],
@@ -16,12 +16,12 @@
         <div class="app-main-header">
           <div>
             <p class="app-main-subtitle">Klasse <%= classData.name %></p>
-            <h1>Schueler verwalten</h1>
-            <p class="admin-muted">Faecher: <%= classData.assigned_subjects_label %> - Lehrer: <%= classData.teacher_emails || '-' %></p>
+            <h1>Schüler verwalten</h1>
+            <p class="admin-muted">Fächer: <%= classData.assigned_subjects_label %> - Lehrer: <%= classData.teacher_emails || '-' %></p>
           </div>
           <div class="admin-actions-row">
-            <a class="btn btn-primary" href="/admin/classes/<%= classData.id %>/students/add">+ Schueler hinzufuegen</a>
-            <a class="btn btn-secondary" href="/admin/classes">Zurueck</a>
+            <a class="btn btn-primary" href="/admin/classes/<%= classData.id %>/students/add">+ Schüler hinzufügen</a>
+            <a class="btn btn-secondary" href="/admin/classes">Zurück</a>
           </div>
         </div>
 
@@ -29,25 +29,25 @@
           <div class="admin-topbar">
             <div>
               <p class="admin-eyebrow">Suche</p>
-              <h3>Schueler filtern</h3>
+              <h3>Schüler filtern</h3>
             </div>
           </div>
           <form class="admin-form" method="GET" action="/admin/classes/<%= classData.id %>/students">
             <input type="text" name="name" placeholder="Name" value="<%= search.name || '' %>">
             <input type="text" name="email" placeholder="E-Mail" value="<%= search.email || '' %>">
             <button class="btn btn-secondary" type="submit">Suchen</button>
-            <a class="btn" href="/admin/classes/<%= classData.id %>/students">Zuruecksetzen</a>
+            <a class="btn" href="/admin/classes/<%= classData.id %>/students">Zurücksetzen</a>
           </form>
         </div>
 
         <div class="admin-card">
           <div class="admin-topbar">
-            <p class="admin-eyebrow">Schueler</p>
-            <span class="admin-badge"><%= students.length %> Eintraege</span>
+            <p class="admin-eyebrow">Schüler</p>
+            <span class="admin-badge"><%= students.length %> Einträge</span>
           </div>
           <div class="admin-list">
             <% if (students.length === 0) { %>
-              <div class="admin-empty">Noch keine Schueler vorhanden.</div>
+              <div class="admin-empty">Noch keine Schüler vorhanden.</div>
             <% } else { %>
               <% students.forEach(function(student){ %>
                 <div class="admin-student-row">
@@ -58,9 +58,9 @@
                   <form
                     method="POST"
                     action="/admin/classes/<%= classData.id %>/students/<%= student.id %>/delete"
-                    data-confirm-title="Schueler entfernen"
-                    data-confirm-message="Moechtest du diesen Schueler wirklich aus der Klasse entfernen?"
-                    data-confirm-note="Die Zuordnung des Schuelers zu dieser Klasse wird entfernt."
+                    data-confirm-title="Schüler entfernen"
+                    data-confirm-message="Möchtest du diesen Schüler wirklich aus der Klasse entfernen?"
+                    data-confirm-note="Die Zuordnung des Schülers zu dieser Klasse wird entfernt."
                     data-confirm-action="Entfernen"
                     data-confirm-variant="danger"
                   >

--- a/school-login/views/admin/classes.ejs
+++ b/school-login/views/admin/classes.ejs
@@ -16,7 +16,7 @@
           <div>
             <p class="app-main-subtitle">Klassen</p>
             <h1>Alle Klassen verwalten</h1>
-            <p class="admin-muted">Klassen sind eigenstaendig. Faecher und Lehrer werden separat zugeordnet.</p>
+            <p class="admin-muted">Klassen sind eigenständig. Fächer und Lehrer werden separat zugeordnet.</p>
           </div>
           <div class="admin-actions-row">
             <a class="btn btn-secondary" href="/admin/assignments/new">Fach zuordnen</a>
@@ -33,14 +33,14 @@
             <span class="admin-badge"><%= classes.length %> Treffer</span>
           </div>
           <form class="admin-form" method="GET" action="/admin/classes">
-            <input type="text" name="q" placeholder="Name, Faecher oder Lehrer" value="<%= query %>">
+            <input type="text" name="q" placeholder="Name, Fächer oder Lehrer" value="<%= query %>">
             <button class="btn btn-secondary" type="submit">Suchen</button>
-            <a class="btn" href="/admin/classes">Zuruecksetzen</a>
+            <a class="btn" href="/admin/classes">Zurücksetzen</a>
           </form>
         </div>
 
         <div class="admin-card">
-          <h3 class="admin-heading-spaced">Klassenuebersicht</h3>
+          <h3 class="admin-heading-spaced">Klassenübersicht</h3>
           <div class="admin-grid">
             <% if (classes.length === 0) { %>
               <div class="admin-empty">Keine Klassen gefunden.</div>
@@ -50,26 +50,26 @@
                 <a class="admin-class-card-link" href="/admin/classes/<%= cls.id %>">
                   <p class="admin-eyebrow">Klasse</p>
                   <h4><%= cls.name %></h4>
-                  <p class="admin-muted">Faecher: <%= cls.assigned_subjects_label %></p>
+                  <p class="admin-muted">Fächer: <%= cls.assigned_subjects_label %></p>
                   <p class="admin-muted">Lehrer: <%= cls.teacher_emails || '-' %></p>
                   <p class="admin-muted">Klassenvorstand: <%= cls.head_teacher_email || '-' %></p>
                   <p class="admin-muted">Fachzuordnungen: <%= cls.assignment_count || 0 %></p>
                 </a>
                 <div class="admin-row wrap">
-                  <a class="btn btn-primary" href="/admin/classes/<%= cls.id %>/students">Schueler</a>
+                  <a class="btn btn-primary" href="/admin/classes/<%= cls.id %>/students">Schüler</a>
                   <a class="btn btn-secondary" href="/admin/assignments/new?class=<%= cls.id %>&create_subject=1">Fach erstellen</a>
                   <a class="btn btn-secondary" href="/admin/classes/<%= cls.id %>/edit">Bearbeiten</a>
                   <form
                     method="POST"
                     action="/admin/classes/<%= cls.id %>/delete"
-                    data-confirm-title="Klasse loeschen"
-                    data-confirm-message="Moechtest du diese Klasse wirklich loeschen?"
-                    data-confirm-note="Alle Schuelerzuordnungen in dieser Klasse werden ebenfalls entfernt."
-                    data-confirm-action="Loeschen"
+                    data-confirm-title="Klasse löschen"
+                    data-confirm-message="Möchtest du diese Klasse wirklich löschen?"
+                    data-confirm-note="Alle Schülerzuordnungen in dieser Klasse werden ebenfalls entfernt."
+                    data-confirm-action="Löschen"
                     data-confirm-variant="danger"
                   >
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                    <button class="btn btn-danger" type="submit">Loeschen</button>
+                    <button class="btn btn-danger" type="submit">Löschen</button>
                   </form>
                 </div>
               </div>

--- a/school-login/views/admin/create-class.ejs
+++ b/school-login/views/admin/create-class.ejs
@@ -16,7 +16,7 @@
           <div>
             <p class="app-main-subtitle">Klassen</p>
             <h1>Neue Klasse anlegen</h1>
-            <p class="admin-muted">Lege zuerst nur die Klasse an. Faecher und Lehrer werden spaeter separat zugeordnet.</p>
+            <p class="admin-muted">Lege zuerst nur die Klasse an. Fächer und Lehrer werden später separat zugeordnet.</p>
           </div>
         </div>
 

--- a/school-login/views/admin/create-user.ejs
+++ b/school-login/views/admin/create-user.ejs
@@ -48,7 +48,7 @@
                 <div class="admin-panel-head">
                   <div>
                     <h3>Einzelnen Nutzer anlegen</h3>
-                    <p class="admin-muted">Fuer einzelne Korrekturen, Admin-Konten oder neue Eintritte.</p>
+                    <p class="admin-muted">Für einzelne Korrekturen, Admin-Konten oder neue Eintritte.</p>
                   </div>
                 </div>
 
@@ -64,7 +64,7 @@
                     <label class="admin-field">
                       <span>Rolle</span>
                       <select name="role">
-                        <option value="student" <%= (singleValues.role || 'student') === 'student' ? 'selected' : '' %>>Schueler</option>
+                        <option value="student" <%= (singleValues.role || 'student') === 'student' ? 'selected' : '' %>>Schüler</option>
                         <option value="teacher" <%= singleValues.role === 'teacher' ? 'selected' : '' %>>Lehrer</option>
                         <option value="admin" <%= singleValues.role === 'admin' ? 'selected' : '' %>>Admin</option>
                       </select>
@@ -93,7 +93,7 @@
                 <div class="admin-panel-head">
                   <div>
                     <h3>Bulk-Anlage</h3>
-                    <p class="admin-muted">Eine E-Mail pro Zeile. Rolle und Passwortregel gelten fuer alle Eintraege.</p>
+                    <p class="admin-muted">Eine E-Mail pro Zeile. Rolle und Passwortregel gelten für alle Einträge.</p>
                   </div>
                 </div>
 
@@ -143,7 +143,7 @@
                     <label class="admin-field">
                       <span>Rolle</span>
                       <select name="bulkRole">
-                        <option value="student" <%= (bulkValues.bulkRole || 'student') === 'student' ? 'selected' : '' %>>Schueler</option>
+                        <option value="student" <%= (bulkValues.bulkRole || 'student') === 'student' ? 'selected' : '' %>>Schüler</option>
                         <option value="teacher" <%= bulkValues.bulkRole === 'teacher' ? 'selected' : '' %>>Lehrer</option>
                         <option value="admin" <%= bulkValues.bulkRole === 'admin' ? 'selected' : '' %>>Admin</option>
                       </select>
@@ -151,7 +151,7 @@
 
                     <label class="admin-field">
                       <span>Gemeinsames Passwort</span>
-                      <input name="bulkPassword" type="password" placeholder="Ein Passwort fuer alle">
+                      <input name="bulkPassword" type="password" placeholder="Ein Passwort für alle">
                     </label>
                   </div>
 
@@ -189,7 +189,7 @@
                           <% }) %>
                         </ul>
                       <% } else { %>
-                        <p class="admin-muted">Keine fehlgeschlagenen Eintraege.</p>
+                        <p class="admin-muted">Keine fehlgeschlagenen Einträge.</p>
                       <% } %>
                     </div>
                   </div>

--- a/school-login/views/admin/edit-class.ejs
+++ b/school-login/views/admin/edit-class.ejs
@@ -16,9 +16,9 @@
           <div>
             <p class="app-main-subtitle">Klassen</p>
             <h1>Klasse bearbeiten</h1>
-            <p class="admin-muted">Hier wird nur der Klassenname gepflegt. Faecher und Lehrer laufen ueber die Fachzuordnungen.</p>
+            <p class="admin-muted">Hier wird nur der Klassenname gepflegt. Fächer und Lehrer laufen über die Fachzuordnungen.</p>
           </div>
-          <a class="btn btn-secondary" href="/admin/classes">Zurueck</a>
+          <a class="btn btn-secondary" href="/admin/classes">Zurück</a>
         </div>
 
         <div class="admin-card-narrow">

--- a/school-login/views/admin/edit.ejs
+++ b/school-login/views/admin/edit.ejs
@@ -60,10 +60,10 @@
             class="admin-edit-form"
             method="POST"
             action="/admin/users/<%= user.id %>/delete"
-            data-confirm-title="Nutzer loeschen"
-            data-confirm-message="Moechtest du diesen Nutzer wirklich loeschen?"
+            data-confirm-title="Nutzer löschen"
+            data-confirm-message="Möchtest du diesen Nutzer wirklich löschen?"
             data-confirm-note="Der Nutzer wird per Soft-Delete deaktiviert."
-            data-confirm-action="Loeschen"
+            data-confirm-action="Löschen"
             data-confirm-variant="danger"
           >
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">

--- a/school-login/views/admin/home-school-year.ejs
+++ b/school-login/views/admin/home-school-year.ejs
@@ -35,18 +35,18 @@
           </div>
 
           <div class="admin-home-stats">
-            <a class="admin-home-stat" href="/admin/users" aria-label="Nutzerverwaltung oeffnen">
+            <a class="admin-home-stat" href="/admin/users" aria-label="Nutzerverwaltung öffnen">
               <span class="admin-eyebrow">Nutzer</span>
               <strong><%= stats.users %></strong>
             </a>
 
-            <a class="admin-home-stat" href="/admin/classes" aria-label="Klassenbereich oeffnen">
+            <a class="admin-home-stat" href="/admin/classes" aria-label="Klassenbereich öffnen">
               <span class="admin-eyebrow">Klassen</span>
               <strong><%= stats.classes %></strong>
             </a>
 
-            <a class="admin-home-stat" href="/admin/classes" aria-label="Schuelerbereich oeffnen">
-              <span class="admin-eyebrow">Schueler</span>
+            <a class="admin-home-stat" href="/admin/classes" aria-label="Schülerbereich öffnen">
+              <span class="admin-eyebrow">Schüler</span>
               <strong><%= stats.students %></strong>
             </a>
           </div>
@@ -70,7 +70,7 @@
             <h2>Platzhalter</h2>
 
             <button class="btn admin-home-disabled-button" type="button" disabled>
-              Tutorial-Seite noch nicht verfuegbar
+              Tutorial-Seite noch nicht verfügbar
             </button>
           </div>
         </div>

--- a/school-login/views/admin/index.ejs
+++ b/school-login/views/admin/index.ejs
@@ -91,10 +91,10 @@
                     <form
                       method="POST"
                       action="/admin/users/<%= u.id %>/delete"
-                      data-confirm-title="Nutzer loeschen"
-                      data-confirm-message="Moechtest du diesen Nutzer wirklich loeschen?"
+                      data-confirm-title="Nutzer löschen"
+                      data-confirm-message="Möchtest du diesen Nutzer wirklich löschen?"
                       data-confirm-note="Der Nutzer wird per Soft-Delete deaktiviert."
-                      data-confirm-action="Loeschen"
+                      data-confirm-action="Löschen"
                       data-confirm-variant="danger"
                     >
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">

--- a/school-login/views/admin/nav-school-year.ejs
+++ b/school-login/views/admin/nav-school-year.ejs
@@ -15,7 +15,7 @@
 
     <div class="nav-section">
       <div class="nav-section-title">Klassen</div>
-      <a class="<%= activePath.startsWith('/admin/classes') && !activePath.endsWith('/new') ? 'is-active' : '' %>" href="/admin/classes">Uebersicht</a>
+      <a class="<%= activePath.startsWith('/admin/classes') && !activePath.endsWith('/new') ? 'is-active' : '' %>" href="/admin/classes">Übersicht</a>
       <a class="<%= activePath === '/admin/classes/new' ? 'is-active' : '' %>" href="/admin/classes/new">Klasse erstellen</a>
       <a class="<%= activePath.startsWith('/admin/assignments') ? 'is-active' : '' %>" href="/admin/assignments">Unterrichtszuordnung</a>
     </div>

--- a/school-login/views/admin/rollover.ejs
+++ b/school-login/views/admin/rollover.ejs
@@ -13,7 +13,7 @@
   const sourceClassMap = new Map(sourceClasses.map((classRow) => [Number(classRow.id), classRow]));
   const startValues = startForm || {};
   const routeActiveName = draft?.activeSchoolYear?.name || preview?.activeSchoolYear?.name || activeSchoolYear?.name || 'Nicht gesetzt';
-  const routeNextName = draft?.nextSchoolYear?.name || preview?.nextSchoolYear?.name || startValues.schoolYearName || 'Nicht verfuegbar';
+  const routeNextName = draft?.nextSchoolYear?.name || preview?.nextSchoolYear?.name || startValues.schoolYearName || 'Nicht verfügbar';
   const routeActiveStart = draft?.activeSchoolYear?.start_date || preview?.activeSchoolYear?.start_date || activeSchoolYear?.start_date;
   const routeActiveEnd = draft?.activeSchoolYear?.end_date || preview?.activeSchoolYear?.end_date || activeSchoolYear?.end_date;
   const routeNextStart = draft?.nextSchoolYear?.startDate || preview?.nextSchoolYear?.startDate || startValues.startDate;
@@ -68,12 +68,12 @@
             <p class="app-main-subtitle">Schuljahresverwaltung</p>
             <h1>Schuljahreswechsel-Assistent</h1>
             <p class="admin-muted school-year-header-copy">
-              Mehrstufiger Wizard fuer Klassen, Lehrerzuordnungen und Schueleruebernahme.
+              Mehrstufiger Wizard für Klassen, Lehrerzuordnungen und Schülerübernahme.
             </p>
           </div>
           <div class="admin-actions-row school-year-header-actions">
             <% if (hasWizard) { %>
-              <a class="btn btn-primary" href="/admin/rollover?step=<%= wizardStep === 'start' ? 'classes' : wizardStep %>">Assistent oeffnen</a>
+              <a class="btn btn-primary" href="/admin/rollover?step=<%= wizardStep === 'start' ? 'classes' : wizardStep %>">Assistent öffnen</a>
             <% } %>
             <a class="btn btn-secondary" href="/archive">Archiv</a>
           </div>
@@ -89,7 +89,7 @@
             <% } %>
             <% if (intakeParseErrors.length) { %>
               <div class="school-year-alert school-year-alert-error">
-                <strong>Import pruefen:</strong>
+                <strong>Import prüfen:</strong>
                 <ul class="school-year-inline-list">
                   <% intakeParseErrors.forEach((entry) => { %>
                     <li><%= entry %></li>
@@ -122,7 +122,7 @@
               <% if (hasWizard) { %>
                 <form method="POST" action="/admin/rollover/reset">
                   <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                  <button class="btn btn-secondary" type="submit">Assistent zuruecksetzen</button>
+                  <button class="btn btn-secondary" type="submit">Assistent zurücksetzen</button>
                 </form>
               <% } %>
             </div>
@@ -145,7 +145,7 @@
 
                 <div class="school-year-metric-grid">
                   <div class="school-year-metric"><span>Klassen</span><strong><%= draft?.sourceSummary?.classCount || preview?.classCount || 0 %></strong></div>
-                  <div class="school-year-metric"><span>Schueler</span><strong><%= draft?.sourceSummary?.studentCount || preview?.studentCount || 0 %></strong></div>
+                  <div class="school-year-metric"><span>Schüler</span><strong><%= draft?.sourceSummary?.studentCount || preview?.studentCount || 0 %></strong></div>
                   <div class="school-year-metric"><span>Zuordnungen</span><strong><%= draft?.sourceSummary?.assignmentCount || preview?.assignmentsCopied || 0 %></strong></div>
                   <div class="school-year-metric"><span>Archivierte Noten</span><strong><%= draft?.sourceSummary?.gradeCount || preview?.gradeCount || 0 %></strong></div>
                 </div>
@@ -158,7 +158,7 @@
                       <p class="admin-eyebrow">Zielschuljahr</p>
                       <h3>Aktueller Wizard</h3>
                     </div>
-                    <small>Zum Aendern Assistent zuerst zuruecksetzen.</small>
+                    <small>Zum Ändern Assistent zuerst zurücksetzen.</small>
                   </div>
 
                   <div class="school-year-start-readonly">
@@ -187,7 +187,7 @@
                       <p class="admin-eyebrow">Zielschuljahr</p>
                       <h3>Bezeichnung und Datum festlegen</h3>
                     </div>
-                    <small>Standardwerte koennen vor dem Start angepasst werden.</small>
+                    <small>Standardwerte können vor dem Start angepasst werden.</small>
                   </div>
 
                   <form method="POST" action="/admin/rollover/start" class="school-year-form-stack school-year-start-form">
@@ -278,7 +278,7 @@
                     <tr>
                       <th>Typ</th>
                       <th>Quelle</th>
-                      <th>Schueler</th>
+                      <th>Schüler</th>
                       <th>Zielname</th>
                       <th>Lehrer</th>
                       <th>Aktiv</th>
@@ -340,7 +340,7 @@
                           <td>
                             <input type="hidden" name="extra_rows[<%= index %>][plan_key]" value="<%= plan?.key || '' %>">
                             <select name="extra_rows[<%= index %>][template_source_class_id]" class="form-select">
-                              <option value="">Vorlage waehlen</option>
+                              <option value="">Vorlage wählen</option>
                               <% sourceClasses.forEach((classRow) => { %>
                                 <option value="<%= classRow.id %>" <%= Number(plan?.templateSourceClassId) === Number(classRow.id) ? 'selected' : '' %>>
                                   <%= classRow.name %> / <%= classRow.subject %>
@@ -372,7 +372,7 @@
 
               <div class="school-year-button-row">
                 <button class="btn btn-secondary" type="submit" name="intent" value="stay">Speichern</button>
-                <button class="btn btn-primary" type="submit" name="intent" value="next">Weiter zu Schuelern</button>
+                <button class="btn btn-primary" type="submit" name="intent" value="next">Weiter zu Schülern</button>
               </div>
             </form>
           </section>
@@ -383,12 +383,12 @@
             <div class="school-year-panel-head">
               <div>
                 <p class="admin-eyebrow">Schritt 2</p>
-                <h2>Schueler planen</h2>
+                <h2>Schüler planen</h2>
               </div>
               <div class="school-year-panel-meta">
                 <span><%= sourceClassGroups.length %> Ausgangsklassen</span>
-                <span><%= validation.reviewStats.promotedStudentCount || 0 %> Uebernahmen</span>
-                <span><%= validation.reviewStats.intakeStudentCount || 0 %> neue Schueler</span>
+                <span><%= validation.reviewStats.promotedStudentCount || 0 %> Übernahmen</span>
+                <span><%= validation.reviewStats.intakeStudentCount || 0 %> neue Schüler</span>
               </div>
             </div>
 
@@ -406,15 +406,15 @@
                 <details class="school-year-student-group" data-rollover-student-group <%= index < 3 ? 'open' : '' %>>
                   <summary>
                     <span><strong><%= group.classRow.name %></strong> / <%= group.classRow.subject %></span>
-                    <small><%= group.students.length %> Schueler | <%= group.promoteCount %> uebernehmen | <%= group.graduateCount %> beenden</small>
+                    <small><%= group.students.length %> Schüler | <%= group.promoteCount %> übernehmen | <%= group.graduateCount %> beenden</small>
                   </summary>
                   <div class="school-year-group-body">
                     <div class="school-year-group-defaults">
                       <label>
                         <span>Standardaktion</span>
                         <select name="student_defaults[<%= group.classRow.id %>][default_action]" class="form-select">
-                          <option value="promote" <%= group.defaults.defaultAction === 'promote' ? 'selected' : '' %>>In Zielklasse uebernehmen</option>
-                          <option value="graduate" <%= group.defaults.defaultAction === 'graduate' ? 'selected' : '' %>>Nicht uebernehmen</option>
+                          <option value="promote" <%= group.defaults.defaultAction === 'promote' ? 'selected' : '' %>>In Zielklasse übernehmen</option>
+                          <option value="graduate" <%= group.defaults.defaultAction === 'graduate' ? 'selected' : '' %>>Nicht übernehmen</option>
                         </select>
                       </label>
                       <label>
@@ -452,8 +452,8 @@
                               </td>
                               <td>
                                 <select name="student_overrides[<%= studentPlan.sourceStudentId %>][action]" class="form-select">
-                                  <option value="promote" <%= studentPlan.action === 'promote' ? 'selected' : '' %>>Uebernehmen</option>
-                                  <option value="graduate" <%= studentPlan.action === 'graduate' ? 'selected' : '' %>>Nicht uebernehmen</option>
+                                  <option value="promote" <%= studentPlan.action === 'promote' ? 'selected' : '' %>>Übernehmen</option>
+                                  <option value="graduate" <%= studentPlan.action === 'graduate' ? 'selected' : '' %>>Nicht übernehmen</option>
                                 </select>
                               </td>
                               <td>
@@ -477,8 +477,8 @@
                 <section class="school-year-subpanel">
                   <div class="school-year-subpanel-head">
                     <div>
-                      <p class="admin-eyebrow">Neue Schueler</p>
-                      <h3>Intake und Zusatzklassen fuellen</h3>
+                      <p class="admin-eyebrow">Neue Schüler</p>
+                      <h3>Intake und Zusatzklassen füllen</h3>
                     </div>
                     <small>Format pro Zeile: <code>Name;E-Mail</code> oder <code>E-Mail</code></small>
                   </div>
@@ -492,7 +492,7 @@
                           rows="6"
                           placeholder="Max Mustermann;max.mustermann@schule.at"
                         ><%= target.rawText %></textarea>
-                        <small><%= target.students.length %> neue Schueler erkannt</small>
+                        <small><%= target.students.length %> neue Schüler erkannt</small>
                       </label>
                     <% }) %>
                   </div>
@@ -500,8 +500,8 @@
               <% } %>
 
               <div class="school-year-button-row">
-                <button class="btn btn-secondary" type="submit" name="intent" value="back">Zurueck zu Klassen</button>
-                <button class="btn btn-primary" type="submit" name="intent" value="next">Weiter zur Pruefung</button>
+                <button class="btn btn-secondary" type="submit" name="intent" value="back">Zurück zu Klassen</button>
+                <button class="btn btn-primary" type="submit" name="intent" value="next">Weiter zur Prüfung</button>
               </div>
             </form>
           </section>
@@ -512,12 +512,12 @@
             <div class="school-year-panel-head">
               <div>
                 <p class="admin-eyebrow">Schritt 3</p>
-                <h2>Pruefen und ausfuehren</h2>
+                <h2>Prüfen und ausführen</h2>
               </div>
               <div class="school-year-panel-meta">
                 <span><%= validation.reviewStats.targetClassCount || 0 %> Zielklassen</span>
-                <span><%= validation.reviewStats.promotedStudentCount || 0 %> Schueler uebernehmen</span>
-                <span><%= validation.reviewStats.intakeStudentCount || 0 %> neue Schueler</span>
+                <span><%= validation.reviewStats.promotedStudentCount || 0 %> Schüler übernehmen</span>
+                <span><%= validation.reviewStats.intakeStudentCount || 0 %> neue Schüler</span>
               </div>
             </div>
 
@@ -547,8 +547,8 @@
                     <th>Quelle</th>
                     <th>Zielklasse</th>
                     <th>Lehrer</th>
-                    <th>Uebernahmen</th>
-                    <th>Neue Schueler</th>
+                    <th>Übernahmen</th>
+                    <th>Neue Schüler</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -568,7 +568,7 @@
 
             <form method="POST" action="/admin/rollover/execute" class="school-year-confirm-form">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-              <label for="confirmation_text">Zielschuljahr bestaetigen</label>
+              <label for="confirmation_text">Zielschuljahr bestätigen</label>
               <input
                 id="confirmation_text"
                 class="form-input school-year-confirm-input"
@@ -579,12 +579,12 @@
                 required
               >
               <small class="admin-muted school-year-confirm-note">
-                Gib exakt <strong><%= draft?.nextSchoolYear?.name || '-' %></strong> ein. Vor der Ausfuehrung wird ein Backup erzeugt.
+                Gib exakt <strong><%= draft?.nextSchoolYear?.name || '-' %></strong> ein. Vor der Ausführung wird ein Backup erzeugt.
               </small>
 
               <div class="school-year-button-row">
-                <a class="btn btn-secondary" href="/admin/rollover?step=students">Zurueck zu Schuelern</a>
-                <button class="btn btn-danger" type="submit" <%= validation.valid ? '' : 'disabled' %>>Schuljahreswechsel ausfuehren</button>
+                <a class="btn btn-secondary" href="/admin/rollover?step=students">Zurück zu Schülern</a>
+                <button class="btn btn-danger" type="submit" <%= validation.valid ? '' : 'disabled' %>>Schuljahreswechsel ausführen</button>
               </div>
             </form>
           </section>
@@ -622,7 +622,7 @@
                         <button class="btn btn-secondary" type="submit">Schuljahr wiederherstellen</button>
                       </form>
                     <% } else if (String(logRow.status || '').toLowerCase() === 'success' && logRow.backup_path) { %>
-                      <small>Restore nur moeglich, wenn <%= logRow.new_school_year %> aktiv ist.</small>
+                      <small>Restore nur möglich, wenn <%= logRow.new_school_year %> aktiv ist.</small>
                     <% } %>
                   </div>
                 </div>

--- a/school-login/views/admin/user-details.ejs
+++ b/school-login/views/admin/user-details.ejs
@@ -25,7 +25,7 @@
           </div>
           <div class="admin-actions-row">
             <a class="btn btn-secondary" href="/admin/users/<%= user.id %>/edit">Bearbeiten</a>
-            <a class="btn" href="/admin/users">ZurÃ¼ck</a>
+            <a class="btn" href="/admin/users">Zurück</a>
           </div>
         </div>
 
@@ -73,17 +73,17 @@
         <div class="admin-card">
           <div class="admin-topbar">
             <p class="admin-eyebrow">Klassen</p>
-            <span class="admin-badge"><%= classes.length %> EintrÃ¤ge</span>
+            <span class="admin-badge"><%= classes.length %> Einträge</span>
           </div>
           <div class="admin-list">
             <% if (!classes || classes.length === 0) { %>
               <div class="admin-empty">
                 <% if (isStudent) { %>
-                  Keine Klassen fÃ¼r diesen SchÃ¼ler gefunden.
+                  Keine Klassen für diesen Schüler gefunden.
                 <% } else if (isTeacher) { %>
-                  Keine Klassen fÃ¼r diesen Lehrer gefunden.
+                  Keine Klassen für diesen Lehrer gefunden.
                 <% } else { %>
-                  Keine Klasseninfos fÃ¼r diese Rolle vorhanden.
+                  Keine Klasseninfos für diese Rolle vorhanden.
                 <% } %>
               </div>
             <% } else if (isTeacher) { %>
@@ -94,7 +94,7 @@
                     <p class="admin-muted">Fach: <%= entry.subject %></p>
                   </div>
                   <div class="admin-actions-row">
-                    <a class="btn btn-secondary" href="/admin/classes/<%= entry.id %>/students">SchÃ¼ler anzeigen</a>
+                    <a class="btn btn-secondary" href="/admin/classes/<%= entry.id %>/students">Schüler anzeigen</a>
                   </div>
                 </div>
               <% }) %>

--- a/school-login/views/admin/users.ejs
+++ b/school-login/views/admin/users.ejs
@@ -75,10 +75,10 @@
                     <form
                       method="POST"
                       action="/admin/users/<%= u.id %>/delete"
-                      data-confirm-title="Nutzer loeschen"
-                      data-confirm-message="Moechtest du diesen Nutzer wirklich loeschen?"
+                      data-confirm-title="Nutzer löschen"
+                      data-confirm-message="Möchtest du diesen Nutzer wirklich löschen?"
                       data-confirm-note="Der Nutzer wird per Soft-Delete deaktiviert."
-                      data-confirm-action="Loeschen"
+                      data-confirm-action="Löschen"
                       data-confirm-variant="danger"
                     >
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">

--- a/school-login/views/dashboard.ejs
+++ b/school-login/views/dashboard.ejs
@@ -30,7 +30,7 @@
         </div>
         <form class="logout-form" method="POST" action="/logout">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-          <button class="logout-btn" type="submit">Session loeschen</button>
+          <button class="logout-btn" type="submit">Session löschen</button>
         </form>
       </div>
     </div>

--- a/school-login/views/force-password-change.ejs
+++ b/school-login/views/force-password-change.ejs
@@ -29,7 +29,7 @@
       <div class="login-modal is-visible" role="alertdialog" aria-modal="true">
         <div class="login-modal-content">
           <h2>Passwortwechsel erforderlich</h2>
-          <p>Um die Anwendung nutzen zu koennen, muss das Initial-Kennwort sofort geaendert werden.</p>
+          <p>Um die Anwendung nutzen zu können, muss das Initial-Kennwort sofort geändert werden.</p>
           <ul>
             <li>Gib ein neues, sicheres Passwort ein.</li>
             <li>Nach dem Speichern wirst du automatisch weitergeleitet.</li>

--- a/school-login/views/student-dashboard.ejs
+++ b/school-login/views/student-dashboard.ejs
@@ -1,11 +1,11 @@
 <%
   const pageMeta = {
-    overview: { title: "Schueler - Uebersicht", heading: "Uebersicht" },
-    tasks: { title: "Schueler - Aufgaben", heading: "Aufgaben" },
-    returns: { title: "Schueler - Rueckgaben", heading: "Rueckgaben" },
-    requests: { title: "Schueler - Anfragen", heading: "Anfragen" },
-    grades: { title: "Schueler - Noten", heading: "Noten" },
-    archive: { title: "Schueler - Archiv", heading: "Archiv" }
+    overview: { title: "Schüler - Übersicht", heading: "Übersicht" },
+    tasks: { title: "Schüler - Aufgaben", heading: "Aufgaben" },
+    returns: { title: "Schüler - Rückgaben", heading: "Rückgaben" },
+    requests: { title: "Schüler - Anfragen", heading: "Anfragen" },
+    grades: { title: "Schüler - Noten", heading: "Noten" },
+    archive: { title: "Schüler - Archiv", heading: "Archiv" }
   };
   const requestedPage = typeof activePage !== "undefined" ? String(activePage) : "overview";
   const currentPage = pageMeta[requestedPage] ? requestedPage : "overview";
@@ -17,24 +17,24 @@
   const schoolYearLabel = studentProfile.schoolYear || resolvedActiveSchoolYear?.name || "-";
   const page = {
     title: currentMeta.title,
-    headerTitle: "Schuelerbereich",
+    headerTitle: "Schülerbereich",
     styles: ["/css/student-dashboard.css"],
     scripts: ["/js/app.js", "/js/student-dashboard.js"],
     bodyClass: "page-student",
     hideHeader: true,
     hideFooter: true,
     content: function () { %>
-    <button class="mobile-nav-toggle" aria-label="Navigation oeffnen"></button>
+    <button class="mobile-nav-toggle" aria-label="Navigation öffnen"></button>
     <div class="app-shell app-shell-wide">
-      <aside class="app-sidebar" aria-label="Schuelernavigation">
+      <aside class="app-sidebar" aria-label="Schülernavigation">
         <%- include('./partials/sidebar-user-card', { user: { email, role: 'student', name: studentProfile.name } }) %>
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">Menue</div>
-            <a class="<%= currentPage === 'overview' ? 'is-active' : '' %>" href="/student">Uebersicht</a>
+            <div class="nav-section-title">Menü</div>
+            <a class="<%= currentPage === 'overview' ? 'is-active' : '' %>" href="/student">Übersicht</a>
             <a class="<%= currentPage === 'tasks' ? 'is-active' : '' %>" href="/student/tasks">Aufgaben</a>
-            <a class="<%= currentPage === 'returns' ? 'is-active' : '' %>" href="/student/returns">Rueckgaben</a>
+            <a class="<%= currentPage === 'returns' ? 'is-active' : '' %>" href="/student/returns">Rückgaben</a>
             <a class="<%= currentPage === 'requests' ? 'is-active' : '' %>" href="/student/requests">Anfragen</a>
             <a class="<%= currentPage === 'grades' ? 'is-active' : '' %>" href="/student/grades">Noten</a>
             <a class="<%= currentPage === 'archive' ? 'is-active' : '' %>" href="/student/archive">Archiv</a>
@@ -80,15 +80,15 @@
             <section id="overview">
               <div class="overview-stats-strip">
                 <div class="stat-inline"><span class="stat-inline-label">Durchschnitt</span><strong class="stat-inline-value" id="overview-average">-</strong></div>
-                <div class="stat-inline"><span class="stat-inline-label">Faecher</span><strong class="stat-inline-value" id="overview-subject-count"><%= safeSubjects.length %></strong></div>
+                <div class="stat-inline"><span class="stat-inline-label">Fächer</span><strong class="stat-inline-value" id="overview-subject-count"><%= safeSubjects.length %></strong></div>
                 <div class="stat-inline"><span class="stat-inline-label">Offene Aufgaben</span><strong class="stat-inline-value" id="overview-open-tasks">-</strong></div>
-                <div class="stat-inline"><span class="stat-inline-label">Rueckgaben</span><strong class="stat-inline-value" id="overview-return-count">-</strong></div>
-                <div class="stat-inline"><span class="stat-inline-label">Offene Rueckfragen</span><strong class="stat-inline-value" id="overview-open-requests">-</strong></div>
+                <div class="stat-inline"><span class="stat-inline-label">Rückgaben</span><strong class="stat-inline-value" id="overview-return-count">-</strong></div>
+                <div class="stat-inline"><span class="stat-inline-label">Offene Rückfragen</span><strong class="stat-inline-value" id="overview-open-requests">-</strong></div>
               </div>
 
               <div class="section-block">
                 <div class="section-block-head">
-                  <h3>Naechste Aufgaben</h3>
+                  <h3>Nächste Aufgaben</h3>
                   <span class="dataset-count" id="overview-upcoming-count">-</span>
                 </div>
                 <div id="overview-upcoming" class="overview-list"></div>
@@ -104,7 +104,7 @@
 
               <div class="section-block">
                 <div class="section-block-head">
-                  <h3>Letzte Rueckgaben</h3>
+                  <h3>Letzte Rückgaben</h3>
                   <span class="dataset-count" id="overview-recent-return-count">-</span>
                 </div>
                 <div id="overview-recent-returns" class="overview-list"></div>
@@ -118,7 +118,7 @@
                 <div class="dataset-head">
                   <div>
                     <h3>Aufgaben</h3>
-                    <p class="dataset-copy">Filterbar und kompakte Liste fuer viele Eintraege.</p>
+                    <p class="dataset-copy">Filterbar und kompakte Liste für viele Einträge.</p>
                   </div>
                   <span class="dataset-count" id="task-count">-</span>
                 </div>
@@ -145,12 +145,12 @@
               <div class="card">
                 <div class="dataset-head">
                   <div>
-                    <h3>Rueckgaben</h3>
-                    <p class="dataset-copy">Alle Rueckgaben mit Fach, Status und direktem Zugriff auf Rueckfragen.</p>
+                    <h3>Rückgaben</h3>
+                    <p class="dataset-copy">Alle Rückgaben mit Fach, Status und direktem Zugriff auf Rückfragen.</p>
                   </div>
                   <span class="dataset-count" id="return-count">-</span>
                 </div>
-                <form id="return-filter" class="filter-grid" aria-label="Rueckgaben filtern">
+                <form id="return-filter" class="filter-grid" aria-label="Rückgaben filtern">
                   <label>Fach
                     <select name="subject" id="return-filter-subject">
                       <option value="">Alle</option>
@@ -174,14 +174,14 @@
                 <div class="dataset-head">
                   <div>
                     <h3>Anfragen</h3>
-                    <p class="dataset-copy">Nur bestehende oder bereits gefuehrte Tickets, sortiert nach Aktivitaet.</p>
+                    <p class="dataset-copy">Nur bestehende oder bereits geführte Tickets, sortiert nach Aktivität.</p>
                   </div>
                   <span class="dataset-count" id="request-count">-</span>
                 </div>
                 <form id="request-filter" class="filter-grid" aria-label="Anfragen filtern">
-                  <label>Rueckgabe
+                  <label>Rückgabe
                     <select name="gradeId" id="request-filter-grade">
-                      <option value="">Alle Rueckgaben</option>
+                      <option value="">Alle Rückgaben</option>
                     </select>
                   </label>
                   <label>Suche
@@ -200,7 +200,7 @@
               <% if (!selectedGradeSubject) { %>
                 <div class="section-block">
                   <div class="section-block-head">
-                    <h3>Fach auswaehlen</h3>
+                    <h3>Fach auswählen</h3>
                     <div class="button-row">
                       <a class="btn small secondary" href="/student/grades.csv">CSV Export</a>
                       <a class="btn small secondary" href="/student/grades.pdf">PDF Export</a>
@@ -213,7 +213,7 @@
                   <div class="section-block-head">
                     <div>
                       <div class="grade-back-link-row">
-                        <a class="btn small secondary" href="/student/grades">Zur Faecheruebersicht</a>
+                        <a class="btn small secondary" href="/student/grades">Zur Fächerübersicht</a>
                       </div>
                       <h3><%= selectedGradeSubject %></h3>
                     </div>
@@ -248,7 +248,7 @@
                     <div class="stat-inline"><span class="stat-inline-label">Fachdurchschnitt</span><strong class="stat-inline-value" id="avg-overall">-</strong></div>
                     <div class="stat-inline"><span class="stat-inline-label">Trend</span><span class="stat-inline-value" id="avg-trend">-</span></div>
                     <div class="stat-inline"><span class="stat-inline-label">Aktualisierung</span><span class="stat-inline-value" id="avg-updated">-</span></div>
-                    <div class="stat-inline"><span class="stat-inline-label">Eintraege</span><strong class="stat-inline-value" id="grade-count">-</strong></div>
+                    <div class="stat-inline"><span class="stat-inline-label">Einträge</span><strong class="stat-inline-value" id="grade-count">-</strong></div>
                   </div>
 
                   <div id="grade-list" aria-live="polite" class="grade-list-flat"></div>
@@ -262,7 +262,7 @@
               <div class="card">
                 <div class="dataset-head">
                   <div>
-                    <h3>Archivierte Pruefungen</h3>
+                    <h3>Archivierte Prüfungen</h3>
                     <p class="dataset-copy">Historische Leistungen mit denselben Filtern wie im Live-Bereich.</p>
                   </div>
                   <span class="dataset-count" id="archive-count">-</span>

--- a/school-login/views/teacher/teacher-add-grade.ejs
+++ b/school-login/views/teacher/teacher-add-grade.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: `Lehrer â€” Bewertung hinzufÃ¼gen`,
+    title: `Lehrer - Bewertung hinzufügen`,
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -25,16 +25,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">SchÃ¼ler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -47,9 +47,9 @@
       <section class="teacher-main">
         <header class="teacher-main-header">
           <div>
-            <p class="teacher-eyebrow">Bewertung hinzufÃ¼gen</p>
+            <p class="teacher-eyebrow">Bewertung hinzufügen</p>
             <h1><%= student.name %></h1>
-            <p class="teacher-muted">Klasse: <%= classData.name %> Â· <%= classData.subject %></p>
+            <p class="teacher-muted">Klasse: <%= classData.name %> · <%= classData.subject %></p>
           </div>
           <div class="teacher-actions-inline">
             <a class="btn btn-secondary" href="/teacher/student-grades/<%= classData.id %>/<%= student.id %>">Abbrechen</a>
@@ -60,7 +60,7 @@
           <div class="teacher-card-header">
             <div>
               <p class="teacher-eyebrow">Neue Bewertung</p>
-              <h3>Bewertung fÃ¼r <%= student.name %> eintragen</h3>
+              <h3>Bewertung für <%= student.name %> eintragen</h3>
             </div>
           </div>
 
@@ -75,7 +75,7 @@
             </div>
           <% } else if (templates.length === 0) { %>
             <div class="teacher-alert error">
-              âš ï¸ Noch keine PrÃ¼fungsvorlagen vorhanden. <a href="/teacher/grade-templates/<%= classData.id %>">Jetzt PrÃ¼fung anlegen</a>
+              Hinweis: Noch keine Prüfungsvorlagen vorhanden. <a href="/teacher/grade-templates/<%= classData.id %>">Jetzt Prüfung anlegen</a>
             </div>
           <% } else { %>
             <form class="teacher-form" method="POST" action="/teacher/add-grade/<%= classData.id %>/<%= student.id %>" enctype="multipart/form-data">
@@ -85,19 +85,19 @@
                 Bewertungsmodus dieses Profils: <strong><%= scoringModeLabel || 'Punkte oder Noten' %></strong>
               </div>
 
-              <label for="template_search">PrÃ¼fung *</label>
+              <label for="template_search">Prüfung *</label>
               <div class="template-picker" id="templatePicker">
                 <div class="template-picker-toolbar">
                   <input
                     type="search"
                     id="template_search"
                     class="template-picker-search"
-                    placeholder="PrÃ¼fung suchen (Name, Kategorie, Datum)"
+                    placeholder="Prüfung suchen (Name, Kategorie, Datum)"
                     autocomplete="off"
                   >
                   <select id="template_sort" class="template-picker-sort" aria-label="Sortierung">
                     <option value="date_desc">Datum: Neueste zuerst</option>
-                    <option value="date_asc">Datum: Ã„lteste zuerst</option>
+                    <option value="date_asc">Datum: Älteste zuerst</option>
                   </select>
                 </div>
 
@@ -150,7 +150,7 @@
                               <%= selected && !isGraded ? 'checked' : '' %>
                               <%= isGraded ? 'disabled' : '' %>
                               required
-                              aria-label="PrÃ¼fung <%= template.name %> auswÃ¤hlen"
+                              aria-label="Prüfung <%= template.name %> auswählen"
                             >
                           </td>
                           <td><strong><%= template.name %></strong></td>
@@ -168,7 +168,7 @@
                         </tr>
                       <% }) %>
                       <tr id="templateNoResults" class="template-empty-row" hidden>
-                        <td colspan="7">Keine passenden PrÃ¼fungen gefunden.</td>
+                        <td colspan="7">Keine passenden Prüfungen gefunden.</td>
                       </tr>
                     </tbody>
                   </table>
@@ -176,7 +176,7 @@
 
                 <p id="templateSelectionInfo" class="template-picker-selection"></p>
               </div>
-              <small class="form-hint">StandardmÃ¤ssig werden die neuesten 3 PrÃ¼fungen gezeigt. Mit Suche oder Sortierung siehst du alle.</small>
+              <small class="form-hint">Standardmäßig werden die neuesten 3 Prüfungen gezeigt. Mit Suche oder Sortierung siehst du alle.</small>
 
               <label class="checkbox-line" for="is_absent">
                 <input
@@ -186,7 +186,7 @@
                   value="1"
                   <%= formData.is_absent ? 'checked' : '' %>
                 >
-                SchÃ¼ler war bei dieser PrÃ¼fung nicht da
+                Schüler war bei dieser Prüfung nicht da
               </label>
               <small class="form-hint">Aktuelle Regel aus Einstellungen: <%= absenceModeLabel %>.</small>
 
@@ -203,7 +203,7 @@
                   placeholder="z.B. 2 oder 2.5"
                   value="<%= formData.grade || '' %>"
                 >
-                <small class="form-hint">Notenskala: 1 (Sehr gut) bis 5 (Nicht genÃ¼gend)</small>
+                <small class="form-hint">Notenskala: 1 (Sehr gut) bis 5 (Nicht genügend)</small>
               <% } %>
 
               <% if (allowsPoints) { %>
@@ -226,7 +226,7 @@
 
               <label for="note">Notiz (optional)</label>
               <textarea id="note" name="note" rows="2" placeholder="z.B. Sehr gute Mitarbeit, kleine Fehler bei Aufgabe 3"><%= formData.note || '' %></textarea>
-              <small class="form-hint">Optional kannst du eine korrigierte Arbeit anhÃ¤ngen oder einen externen Link angeben.</small>
+              <small class="form-hint">Optional kannst du eine korrigierte Arbeit anhängen oder einen externen Link angeben.</small>
 
               <label for="attachment_file">Korrigierte Arbeit hochladen (optional)</label>
               <input type="file" id="attachment_file" name="attachment_file" accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png">
@@ -238,7 +238,7 @@
 
               <div class="teacher-form-actions">
                 <button class="btn btn-primary" type="submit">Bewertung speichern</button>
-                <a class="btn btn-secondary" href="/teacher/student-grades/<%= classData.id %>/<%= student.id %>">ZurÃ¼ck</a>
+                <a class="btn btn-secondary" href="/teacher/student-grades/<%= classData.id %>/<%= student.id %>">Zurück</a>
               </div>
             </form>
           <% } %>
@@ -290,11 +290,11 @@
               const date = cells[5] ? cells[5].innerText.trim() : "";
               selectedMaxPoints = row.dataset.templateMaxPoints || "-";
               selectedLabel = date && date !== "-"
-                ? "AusgewÃ¤hlt: " + name + " (" + date + ")"
-                : "AusgewÃ¤hlt: " + name;
+                ? "Ausgewählt: " + name + " (" + date + ")"
+                : "Ausgewählt: " + name;
             }
           });
-          selectionInfo.textContent = selectedLabel || "Noch keine PrÃ¼fung ausgewÃ¤hlt.";
+          selectionInfo.textContent = selectedLabel || "Noch keine Prüfung ausgewählt.";
           if (templateMaxPointsInfo) {
             templateMaxPointsInfo.textContent = "Maximale Punkte aus Vorlage: " + selectedMaxPoints;
           }

--- a/school-login/views/teacher/teacher-add-student.ejs
+++ b/school-login/views/teacher/teacher-add-student.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: 'Lehrer â€” SchÃ¼ler hinzufÃ¼gen',
+    title: 'Lehrer - Schüler hinzufügen',
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -14,16 +14,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a class="is-active" href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a class="is-active" href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -36,9 +36,9 @@
       <section class="teacher-main">
         <header class="teacher-main-header">
           <div>
-            <p class="teacher-eyebrow">SchÃ¼ler hinzufÃ¼gen</p>
+            <p class="teacher-eyebrow">Schüler hinzufügen</p>
             <h1>Klasse <%= classData.name %></h1>
-            <p class="teacher-muted">Rolle: Lehrer Â· <%= email %></p>
+            <p class="teacher-muted">Rolle: Lehrer · <%= email %></p>
           </div>
           <div class="teacher-actions-inline">
             <a class="btn btn-secondary" href="/teacher/students/<%= classData.id %>">Abbrechen</a>
@@ -48,7 +48,7 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">Neuen SchÃ¼ler verknÃ¼pfen</p>
+              <p class="teacher-eyebrow">Neuen Schüler verknüpfen</p>
               <h3>Bestehenden Benutzer einer Klasse zuweisen</h3>
             </div>
           </div>
@@ -57,20 +57,20 @@
             <div class="teacher-alert error"><%= error %></div>
           <% } %>
 
-          <div class="teacher-alert info">ðŸ’¡ Der SchÃ¼ler muss bereits als Benutzer mit der Rolle "student" existieren.</div>
+          <div class="teacher-alert info">Hinweis: Der Schüler muss bereits als Benutzer mit der Rolle "student" existieren.</div>
 
           <form class="teacher-form" method="POST" action="/teacher/add-student/<%= classData.id %>">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <label for="name">Name des SchÇ¬lers</label>
+            <label for="name">Name des Schülers</label>
             <input type="text" id="name" name="name" placeholder="Max Mustermann" data-student-name>
             <p class="teacher-muted">Wird automatisch gesetzt bei E-Mail im Format vorname.nachname@xy.</p>
 
-            <label for="email">E-Mail des SchÇ¬lers</label>
+            <label for="email">E-Mail des Schülers</label>
             <input type="email" id="email" name="email" required placeholder="max.mustermann@schule.at" data-student-email>
 
             <div class="teacher-form-actions">
-              <button class="btn btn-primary" type="submit">SchÃ¼ler hinzufÃ¼gen</button>
-              <a class="btn btn-secondary" href="/teacher/students/<%= classData.id %>">ZurÃ¼ck</a>
+              <button class="btn btn-primary" type="submit">Schüler hinzufügen</button>
+              <a class="btn btn-secondary" href="/teacher/students/<%= classData.id %>">Zurück</a>
             </div>
           </form>
         </div>

--- a/school-login/views/teacher/teacher-bulk-grade-template.ejs
+++ b/school-login/views/teacher/teacher-bulk-grade-template.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: `Lehrer - Pruefung benoten (${classData.name})`,
+    title: `Lehrer - Prüfung benoten (${classData.name})`,
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -20,15 +20,15 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">Menue</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">Pruefungen</a>
+            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -48,7 +48,7 @@
             </p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">Zurueck zu Pruefungen</a>
+            <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">Zurück zu Prüfungen</a>
           </div>
         </header>
 
@@ -72,10 +72,10 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">Pruefungsdaten</p>
-              <h3>Schuelerliste zum Benoten</h3>
+              <p class="teacher-eyebrow">Prüfungsdaten</p>
+              <h3>Schülerliste zum Benoten</h3>
             </div>
-            <div class="teacher-meta-chip"><%= rows.length %> Schueler</div>
+            <div class="teacher-meta-chip"><%= rows.length %> Schüler</div>
           </div>
 
           <div class="teacher-alert info">
@@ -100,7 +100,7 @@
               <table class="grades-table bulk-grade-table">
                 <thead>
                   <tr>
-                    <th>Schueler</th>
+                    <th>Schüler</th>
                     <th>Status</th>
                     <th>Note (1-5)</th>
                     <th>Punkte</th>
@@ -192,10 +192,10 @@
             </div>
 
             <small class="form-hint">
-              Bereits vorhandene Bewertungen sind vorausgefuellt und koennen bei Bedarf direkt angepasst werden.
+              Bereits vorhandene Bewertungen sind vorausgefüllt und können bei Bedarf direkt angepasst werden.
             </small>
             <p class="form-hint">
-              Tipp: Dezimalwerte koennen mit Punkt oder Komma eingegeben werden.
+              Tipp: Dezimalwerte können mit Punkt oder Komma eingegeben werden.
             </p>
 
             <div class="teacher-form-actions">

--- a/school-login/views/teacher/teacher-class-statistics.ejs
+++ b/school-login/views/teacher/teacher-class-statistics.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: `Lehrer â€” Klassenstatistiken (${classData.name})`,
+    title: `Lehrer - Klassenstatistiken (${classData.name})`,
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -21,11 +21,16 @@
           "wunschpr-fung": "wunschprufung"
         })[
           String(value || "")
-            .replace(/ÃƒÂ¤/g, "Ã¤")
-            .replace(/ÃƒÂ¶/g, "Ã¶")
-            .replace(/ÃƒÂ¼/g, "Ã¼")
-            .replace(/ÃƒÅ¸/g, "ÃŸ")
-            .replace(/Ã‚/g, "")
+            .replace(/\u00c3\u0192\u00c2\u00a4/g, "ä")
+            .replace(/\u00c3\u0192\u00c2\u00b6/g, "ö")
+            .replace(/\u00c3\u0192\u00c2\u00bc/g, "ü")
+            .replace(/\u00c3\u0192\u00c5\u00b8/g, "ß")
+            .replace(/\u00c3\u201a/g, "")
+            .replace(/\u00c3\u00a4/g, "ä")
+            .replace(/\u00c3\u00b6/g, "ö")
+            .replace(/\u00c3\u00bc/g, "ü")
+            .replace(/\u00c3\u0178/g, "ß")
+            .replace(/\u00c2/g, "")
             .normalize("NFD")
             .replace(/[\u0300-\u036f]/g, "")
             .toLowerCase()
@@ -33,11 +38,16 @@
             .replace(/^-+|-+$/g, "")
         ] ||
         String(value || "")
-          .replace(/ÃƒÂ¤/g, "Ã¤")
-          .replace(/ÃƒÂ¶/g, "Ã¶")
-          .replace(/ÃƒÂ¼/g, "Ã¼")
-          .replace(/ÃƒÅ¸/g, "ÃŸ")
-          .replace(/Ã‚/g, "")
+          .replace(/\u00c3\u0192\u00c2\u00a4/g, "ä")
+            .replace(/\u00c3\u0192\u00c2\u00b6/g, "ö")
+            .replace(/\u00c3\u0192\u00c2\u00bc/g, "ü")
+            .replace(/\u00c3\u0192\u00c5\u00b8/g, "ß")
+            .replace(/\u00c3\u201a/g, "")
+            .replace(/\u00c3\u00a4/g, "ä")
+            .replace(/\u00c3\u00b6/g, "ö")
+            .replace(/\u00c3\u00bc/g, "ü")
+            .replace(/\u00c3\u0178/g, "ß")
+            .replace(/\u00c2/g, "")
           .normalize("NFD")
           .replace(/[\u0300-\u036f]/g, "")
           .toLowerCase()
@@ -50,16 +60,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">SchÃ¼ler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a class="is-active" href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -74,32 +84,32 @@
           <div>
             <p class="teacher-eyebrow">Klasse <%= classData.name %></p>
             <h1>Klassenstatistiken</h1>
-            <p class="teacher-muted">Fach: <%= classData.subject %> Â· <%= studentCount %> aktive SchÃ¼ler<% if (excludedStudentCount > 0) { %> Â· <%= excludedStudentCount %> ausgeschlossen<% } %></p>
+            <p class="teacher-muted">Fach: <%= classData.subject %> · <%= studentCount %> aktive Schüler<% if (excludedStudentCount > 0) { %> · <%= excludedStudentCount %> ausgeschlossen<% } %></p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/classes">ZurÃ¼ck</a>
+            <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
           </div>
         </header>
 
-        <!-- GesamtÃ¼bersicht -->
+        <!-- Gesamtübersicht -->
         <% if (overallWeightedAverage || overallAverage) { %>
           <div class="stats-card">
             <div class="stat-item">
               <p class="stat-label">Klassendurchschnitt (gewichtet)</p>
               <p class="stat-value grade-<%= Math.round(overallWeightedAverage) %>">
-                <%= overallWeightedAverage || 'â€”' %>
+                <%= overallWeightedAverage || '-' %>
               </p>
             </div>
             <div class="stat-item">
               <p class="stat-label">Durchschnitt (ungewichtet)</p>
-              <p class="stat-value"><%= overallAverage || 'â€”' %></p>
+              <p class="stat-value"><%= overallAverage || '-' %></p>
             </div>
             <div class="stat-item">
-              <p class="stat-label">Anzahl PrÃ¼fungen</p>
+              <p class="stat-label">Anzahl Prüfungen</p>
               <p class="stat-value"><%= templateStats.length %></p>
             </div>
             <div class="stat-item">
-              <p class="stat-label">Anzahl SchÃ¼ler</p>
+              <p class="stat-label">Anzahl Schüler</p>
               <p class="stat-value"><%= studentCount %></p>
             </div>
           </div>
@@ -108,18 +118,18 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">PrÃ¼fungsstatistiken</p>
-              <h3>Durchschnitt pro PrÃ¼fung</h3>
+              <p class="teacher-eyebrow">Prüfungsstatistiken</p>
+              <h3>Durchschnitt pro Prüfung</h3>
             </div>
-            <div class="teacher-meta-chip"><%= templateStats.length %> PrÃ¼fungen</div>
+            <div class="teacher-meta-chip"><%= templateStats.length %> Prüfungen</div>
           </div>
 
           <div class="statistics-list">
             <% if (templateStats.length === 0) { %>
               <div class="teacher-empty">
-                <h4>Noch keine PrÃ¼fungen</h4>
-                <p>Erstelle PrÃ¼fungsvorlagen, um Statistiken zu sehen.</p>
-                <a class="btn btn-primary" href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen verwalten</a>
+                <h4>Noch keine Prüfungen</h4>
+                <p>Erstelle Prüfungsvorlagen, um Statistiken zu sehen.</p>
+                <a class="btn btn-primary" href="/teacher/grade-templates/<%= classData.id %>">Prüfungen verwalten</a>
               </div>
             <% } else { %>
               <% templateStats.forEach(stat => { %>
@@ -144,7 +154,7 @@
                             <%= stat.average %>
                           </p>
                         <% } else { %>
-                          <p class="statistics-value-empty">â€”</p>
+                          <p class="statistics-value-empty">-</p>
                         <% } %>
                       </div>
 
@@ -171,7 +181,7 @@
                             <% } %>
                           </p>
                         <% } else { %>
-                          <p class="statistics-value-empty">â€”</p>
+                          <p class="statistics-value-empty">-</p>
                         <% } %>
                       </div>
 
@@ -188,7 +198,7 @@
                             <% } %>
                           </p>
                         <% } else { %>
-                          <p class="statistics-value-empty">â€”</p>
+                          <p class="statistics-value-empty">-</p>
                         <% } %>
                       </div>
                     </div>

--- a/school-login/views/teacher/teacher-classes.ejs
+++ b/school-login/views/teacher/teacher-classes.ejs
@@ -8,14 +8,14 @@
     hideHeader: true,
     hideFooter: true,
     content: function () { %>
-    <button class="mobile-nav-toggle" aria-label="Navigation oeffnen"></button>
+    <button class="mobile-nav-toggle" aria-label="Navigation öffnen"></button>
     <div class="app-shell teacher-shell">
       <aside class="teacher-sidebar" aria-label="Lehrer Navigation">
         <%- include('../partials/sidebar-user-card', { user: { email, role: 'teacher' } }) %>
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">Menue</div>
+            <div class="nav-section-title">Menü</div>
             <a class="is-active" href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
@@ -30,7 +30,7 @@
       <section class="teacher-main">
         <header class="teacher-main-header">
           <div>
-            <p class="teacher-eyebrow">Uebersicht</p>
+            <p class="teacher-eyebrow">Übersicht</p>
             <h1>Fächer</h1>
             <p class="teacher-muted">Rolle: Lehrer · <%= email %></p>
           </div>
@@ -50,7 +50,7 @@
           >
           <select class="form-select teacher-search-select" name="sort" aria-label="Sortierung">
             <option value="newest" <%= (search && search.sort) === 'newest' ? 'selected' : '' %>>Neueste zuerst</option>
-            <option value="oldest" <%= (search && search.sort) === 'oldest' ? 'selected' : '' %>>Aelteste zuerst</option>
+            <option value="oldest" <%= (search && search.sort) === 'oldest' ? 'selected' : '' %>>Älteste zuerst</option>
             <option value="name_asc" <%= (search && search.sort) === 'name_asc' ? 'selected' : '' %>>Name A-Z</option>
             <option value="name_desc" <%= (search && search.sort) === 'name_desc' ? 'selected' : '' %>>Name Z-A</option>
             <option value="subject_asc" <%= (search && search.sort) === 'subject_asc' ? 'selected' : '' %>>Fach A-Z</option>
@@ -63,7 +63,7 @@
         <% if (!setupComplete) { %>
           <div class="teacher-alert error">
             Bitte richte zuerst dein Bewertungsschema ein:
-            <a href="/teacher/settings?setup=1">Jetzt Einstellungen oeffnen</a>
+            <a href="/teacher/settings?setup=1">Jetzt Einstellungen öffnen</a>
           </div>
         <% } else if (activeProfile) { %>
           <div class="teacher-alert info">
@@ -78,7 +78,7 @@
               <p class="teacher-eyebrow">Zuordnungen</p>
               <h3>Aktive Fachzuordnungen</h3>
             </div>
-            <div class="teacher-meta-chip"><%= classes.length %> / <%= totalClassCount %> Eintraege</div>
+            <div class="teacher-meta-chip"><%= classes.length %> / <%= totalClassCount %> Einträge</div>
           </div>
 
           <div class="teacher-grid">

--- a/school-login/views/teacher/teacher-create-class.ejs
+++ b/school-login/views/teacher/teacher-create-class.ejs
@@ -14,7 +14,7 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">Menue</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a class="is-active" href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
@@ -55,7 +55,7 @@
 
             <label for="class_id">Klasse</label>
             <select id="class_id" name="class_id" required>
-              <option value="">Bitte waehlen</option>
+              <option value="">Bitte wählen</option>
               <% (classes || []).forEach((entry) => { %>
                 <option value="<%= entry.id %>" <%= String((formData && formData.class_id) || '') === String(entry.id) ? 'selected' : '' %>>
                   <%= entry.name %>
@@ -75,7 +75,7 @@
 
             <div class="teacher-form-actions">
               <button class="btn btn-primary" type="submit">Fach erstellen</button>
-              <a class="btn btn-secondary" href="/teacher/classes">Zurueck</a>
+              <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
             </div>
           </form>
         </div>

--- a/school-login/views/teacher/teacher-create-template.ejs
+++ b/school-login/views/teacher/teacher-create-template.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: 'Lehrer - PrÃ¼fung erstellen',
+    title: 'Lehrer - Prüfung erstellen',
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -18,16 +18,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -40,9 +40,9 @@
       <section class="teacher-main">
         <header class="teacher-main-header">
           <div>
-            <p class="teacher-eyebrow">PrÃ¼fung anlegen</p>
+            <p class="teacher-eyebrow">Prüfung anlegen</p>
             <h1>Klasse <%= classData.name %></h1>
-            <p class="teacher-muted">Profil: <strong><%= activeProfile.name %></strong> Â· Modus: Punkte</p>
+            <p class="teacher-muted">Profil: <strong><%= activeProfile.name %></strong> · Modus: Punkte</p>
           </div>
           <div class="teacher-actions-inline">
             <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">Abbrechen</a>
@@ -52,7 +52,7 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">Neue PrÃ¼fungsvorlage</p>
+              <p class="teacher-eyebrow">Neue Prüfungsvorlage</p>
               <h3>Gewichtung wird in Punkten festgelegt</h3>
             </div>
           </div>
@@ -62,13 +62,13 @@
           <% } %>
 
           <div class="teacher-alert info">
-            Du kannst den vorgeschlagenen Punktewert aus dem Profil Ã¼bernehmen oder manuell anpassen.
+            Du kannst den vorgeschlagenen Punktewert aus dem Profil übernehmen oder manuell anpassen.
           </div>
 
           <form class="teacher-form" method="POST" action="/teacher/create-template/<%= classData.id %>">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
 
-            <label for="name">Name der PrÃ¼fung *</label>
+            <label for="name">Name der Prüfung *</label>
             <input
               type="text"
               id="name"
@@ -80,7 +80,7 @@
 
             <label for="category">Kategorie *</label>
             <select id="category" name="category" required>
-              <option value="">-- Kategorie wÃ¤hlen --</option>
+              <option value="">-- Kategorie wählen --</option>
               <% categoryDefinitions.forEach(category => { %>
                 <option
                   value="<%= category.key %>"
@@ -101,7 +101,7 @@
               >
               Gespeicherte Einstellungen aus dem aktiven Profil verwenden
             </label>
-            <small class="form-hint" id="profile-settings-hint">Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch uebernommen und gesperrt.</small>
+            <small class="form-hint" id="profile-settings-hint">Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch übernommen und gesperrt.</small>
 
             <label for="weight">Gewichtung (<span id="weight-unit-label"><%= unitLabel %></span>) *</label>
             <input
@@ -111,7 +111,7 @@
               min="0"
               step="0.5"
               data-manual-required="0"
-              placeholder="Wert leer lassen fÃ¼r Profil-Vorschlag"
+              placeholder="Wert leer lassen für Profil-Vorschlag"
               value="<%= formData && formData.weight !== '' ? formData.weight : '' %>"
               <%= useProfileSettings ? 'disabled' : '' %>
             >
@@ -142,8 +142,8 @@
             ><%= formData && formData.description ? formData.description : '' %></textarea>
 
             <div class="teacher-form-actions">
-              <button class="btn btn-primary" type="submit">PrÃ¼fung anlegen</button>
-              <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">ZurÃ¼ck</a>
+              <button class="btn btn-primary" type="submit">Prüfung anlegen</button>
+              <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">Zurück</a>
             </div>
           </form>
         </div>
@@ -195,13 +195,13 @@
 
           if (profileSettingsHint) {
             profileSettingsHint.textContent = useProfileSettings
-              ? 'Aktives Profil ist eingeschaltet: Gewichtung wird automatisch gesetzt und Maximalpunkte sind schreibgeschuetzt.'
-              : 'Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch uebernommen und gesperrt.';
+              ? 'Aktives Profil ist eingeschaltet: Gewichtung wird automatisch gesetzt und Maximalpunkte sind schreibgeschützt.'
+              : 'Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch übernommen und gesperrt.';
           }
 
           if (maxPointsHint) {
             maxPointsHint.textContent = useProfileSettings
-              ? 'Maximalpunkte koennen bei aktiven Profileinstellungen nicht manuell geaendert werden.'
+              ? 'Maximalpunkte können bei aktiven Profileinstellungen nicht manuell geändert werden.'
               : 'Wenn gesetzt, wird bei der Benotung nur noch "Erreichte Punkte" abgefragt.';
           }
         }
@@ -216,8 +216,8 @@
           if (!selectedCategory) {
             if (weightHint) {
               weightHint.textContent = useProfileSettings
-                ? 'Waehle zuerst eine Kategorie, damit das Profil die Gewichtung setzen kann.'
-                : 'WÃ¤hle zuerst eine Kategorie.';
+                ? 'Wähle zuerst eine Kategorie, damit das Profil die Gewichtung setzen kann.'
+                : 'Wähle zuerst eine Kategorie.';
             }
             syncManagedFieldState(null);
             return;
@@ -233,7 +233,7 @@
               weightInput.value = formatWeight(suggestion);
             }
           } else if (weightHint) {
-            weightHint.textContent = 'Keine Profil-Gewichtung fÃ¼r diese Kategorie gefunden.';
+            weightHint.textContent = 'Keine Profil-Gewichtung für diese Kategorie gefunden.';
           }
           syncManagedFieldState(suggestion);
         }

--- a/school-login/views/teacher/teacher-edit-template.ejs
+++ b/school-login/views/teacher/teacher-edit-template.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: "Lehrer - PrÃ¼fung bearbeiten",
+    title: "Lehrer - Prüfung bearbeiten",
     headerTitle: "Lehrerbereich",
     styles: ["/css/teacher-pages.css"],
     scripts: ["/js/app.js"],
@@ -18,15 +18,15 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">SchÃ¼ler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -39,7 +39,7 @@
       <section class="teacher-main">
         <header class="teacher-main-header">
           <div>
-            <p class="teacher-eyebrow">PrÃ¼fung bearbeiten</p>
+            <p class="teacher-eyebrow">Prüfung bearbeiten</p>
             <h1>Klasse <%= classData.name %></h1>
             <p class="teacher-muted">Profil: <strong><%= activeProfile.name %></strong> - Modus: Punkte</p>
           </div>
@@ -51,7 +51,7 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">PrÃ¼fungsvorlage</p>
+              <p class="teacher-eyebrow">Prüfungsvorlage</p>
               <h3>Details bearbeiten</h3>
             </div>
           </div>
@@ -63,7 +63,7 @@
           <form class="teacher-form" method="POST" action="/teacher/edit-template/<%= classData.id %>/<%= templateId %>">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
 
-            <label for="name">Name der PrÃ¼fung *</label>
+            <label for="name">Name der Prüfung *</label>
             <input
               type="text"
               id="name"
@@ -75,7 +75,7 @@
 
             <label for="category">Kategorie *</label>
             <select id="category" name="category" required>
-              <option value="">-- Kategorie wÃ¤hlen --</option>
+              <option value="">-- Kategorie wählen --</option>
               <% categoryDefinitions.forEach((category) => { %>
                 <option
                   value="<%= category.key %>"
@@ -96,7 +96,7 @@
               >
               Gespeicherte Einstellungen aus dem aktiven Profil verwenden
             </label>
-            <small class="form-hint" id="profile-settings-hint">Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch uebernommen und gesperrt.</small>
+            <small class="form-hint" id="profile-settings-hint">Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch übernommen und gesperrt.</small>
 
             <label for="weight">Gewichtung (<span id="weight-unit-label"><%= unitLabel %></span>) *</label>
             <input
@@ -137,8 +137,8 @@
             ><%= formData && formData.description ? formData.description : '' %></textarea>
 
             <div class="teacher-form-actions">
-              <button class="btn btn-primary" type="submit">Ã„nderungen speichern</button>
-              <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">ZurÃ¼ck</a>
+              <button class="btn btn-primary" type="submit">Änderungen speichern</button>
+              <a class="btn btn-secondary" href="/teacher/grade-templates/<%= classData.id %>">Zurück</a>
             </div>
           </form>
         </div>
@@ -190,13 +190,13 @@
 
           if (profileSettingsHint) {
             profileSettingsHint.textContent = useProfileSettings
-              ? "Aktives Profil ist eingeschaltet: Gewichtung wird automatisch gesetzt und Maximalpunkte bleiben schreibgeschuetzt."
-              : "Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch uebernommen und gesperrt.";
+              ? "Aktives Profil ist eingeschaltet: Gewichtung wird automatisch gesetzt und Maximalpunkte bleiben schreibgeschützt."
+              : "Wenn aktiv, werden Gewichtung und weitere Profilwerte automatisch übernommen und gesperrt.";
           }
 
           if (maxPointsHint) {
             maxPointsHint.textContent = useProfileSettings
-              ? "Maximalpunkte bleiben sichtbar, koennen mit aktiven Profileinstellungen aber nicht bearbeitet werden."
+              ? "Maximalpunkte bleiben sichtbar, können mit aktiven Profileinstellungen aber nicht bearbeitet werden."
               : "Wenn aktiv, bleibt der bisherige Maximalwert sichtbar, aber gesperrt.";
           }
         }
@@ -210,8 +210,8 @@
           if (!selectedCategory) {
             if (weightHint) {
               weightHint.textContent = useProfileSettings
-                ? "Waehle zuerst eine Kategorie, damit das Profil die Gewichtung setzen kann."
-                : "WÃ¤hle zuerst eine Kategorie.";
+                ? "Wähle zuerst eine Kategorie, damit das Profil die Gewichtung setzen kann."
+                : "Wähle zuerst eine Kategorie.";
             }
             syncManagedFieldState(null);
             return;
@@ -228,7 +228,7 @@
             }
           } else if (weightHint) {
             weightHint.textContent =
-              "Keine Profil-Gewichtung fÃ¼r diese Kategorie gefunden.";
+              "Keine Profil-Gewichtung für diese Kategorie gefunden.";
           }
           syncManagedFieldState(suggestion);
         }

--- a/school-login/views/teacher/teacher-grade-templates.ejs
+++ b/school-login/views/teacher/teacher-grade-templates.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: `Lehrer - PrÃ¼fungsvorlagen (${classData.name})`,
+    title: `Lehrer - Prüfungsvorlagen (${classData.name})`,
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -39,16 +39,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a class="is-active" href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -62,7 +62,7 @@
         <header class="teacher-main-header">
           <div>
             <p class="teacher-eyebrow">Klasse <%= classData.name %></p>
-            <h1>PrÃ¼fungsvorlagen</h1>
+            <h1>Prüfungsvorlagen</h1>
             <p class="teacher-muted">
               Fach: <%= classData.subject %>
               <% if (activeProfile) { %>
@@ -71,8 +71,8 @@
             </p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-primary" href="/teacher/create-template/<%= classData.id %>">+ PrÃ¼fung anlegen</a>
-            <a class="btn btn-secondary" href="/teacher/classes">ZurÃ¼ck</a>
+            <a class="btn btn-primary" href="/teacher/create-template/<%= classData.id %>">+ Prüfung anlegen</a>
+            <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
           </div>
         </header>
 
@@ -91,7 +91,7 @@
             class="form-input teacher-search-input"
             type="search"
             name="q"
-            placeholder="PrÃ¼fung, Kategorie oder Datum suchen"
+            placeholder="Prüfung, Kategorie oder Datum suchen"
             value="<%= (search && search.q) || '' %>"
           >
           <select class="form-select teacher-search-select" name="category" aria-label="Kategorie">
@@ -107,7 +107,7 @@
           </select>
           <select class="form-select teacher-search-select" name="sort" aria-label="Sortierung">
             <option value="date_desc" <%= (search && search.sort) === 'date_desc' ? 'selected' : '' %>>Datum (neueste zuerst)</option>
-            <option value="date_asc" <%= (search && search.sort) === 'date_asc' ? 'selected' : '' %>>Datum (Ã¤lteste zuerst)</option>
+            <option value="date_asc" <%= (search && search.sort) === 'date_asc' ? 'selected' : '' %>>Datum (älteste zuerst)</option>
             <option value="name_asc" <%= (search && search.sort) === 'name_asc' ? 'selected' : '' %>>Name A-Z</option>
             <option value="name_desc" <%= (search && search.sort) === 'name_desc' ? 'selected' : '' %>>Name Z-A</option>
             <option value="weight_desc" <%= (search && search.sort) === 'weight_desc' ? 'selected' : '' %>>Gewichtung absteigend</option>
@@ -123,17 +123,17 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">PrÃ¼fungen</p>
-              <h3>VerfÃ¼gbare Vorlagen</h3>
+              <p class="teacher-eyebrow">Prüfungen</p>
+              <h3>Verfügbare Vorlagen</h3>
             </div>
-            <div class="teacher-meta-chip"><%= templates.length %> / <%= totalTemplateCount %> EintrÃ¤ge</div>
+            <div class="teacher-meta-chip"><%= templates.length %> / <%= totalTemplateCount %> Einträge</div>
           </div>
 
           <% if (templates.length === 0) { %>
             <div class="teacher-empty">
-              <h4>Noch keine PrÃ¼fungen angelegt</h4>
+              <h4>Noch keine Prüfungen angelegt</h4>
               <p>Lege zuerst dein Bewertungsschema fest und erstelle dann die erste Vorlage.</p>
-              <a class="btn btn-primary" href="/teacher/create-template/<%= classData.id %>">+ Erste PrÃ¼fung anlegen</a>
+              <a class="btn btn-primary" href="/teacher/create-template/<%= classData.id %>">+ Erste Prüfung anlegen</a>
             </div>
           <% } else { %>
             <div class="grades-table-wrapper">
@@ -141,7 +141,7 @@
                 <thead>
                   <tr>
                     <th>Kategorie</th>
-                    <th>PrÃ¼fung</th>
+                    <th>Prüfung</th>
                     <th>Datum</th>
                     <th>Gewichtung</th>
                     <th>Max. Punkte</th>
@@ -170,7 +170,7 @@
                           <a class="btn btn-secondary btn-sm" href="/teacher/edit-template/<%= classData.id %>/<%= template.id %>">Bearbeiten</a>
                           <form class="inline delete-template-form" method="POST" action="/teacher/delete-template/<%= classData.id %>/<%= template.id %>" data-template-name="<%= template.name %>">
                             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                            <button class="btn btn-danger btn-sm" type="button">LÃ¶schen</button>
+                            <button class="btn btn-danger btn-sm" type="button">Löschen</button>
                           </form>
                         </div>
                       </td>
@@ -187,15 +187,15 @@
     <div id="deleteTemplateModal" class="modal-overlay">
       <div class="modal-content">
         <div class="modal-header">
-          <h3>PrÃ¼fung lÃ¶schen</h3>
+          <h3>Prüfung löschen</h3>
         </div>
         <div class="modal-body">
-          <p>MÃ¶chtest du die PrÃ¼fung <strong id="deleteTemplateName"></strong> wirklich lÃ¶schen?</p>
+          <p>Möchtest du die Prüfung <strong id="deleteTemplateName"></strong> wirklich löschen?</p>
           <p class="teacher-muted">Alle zugeordneten Noten werden ebenfalls entfernt.</p>
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" id="cancelDeleteTemplate">Abbrechen</button>
-          <button class="btn btn-danger" id="confirmDeleteTemplate">LÃ¶schen</button>
+          <button class="btn btn-danger" id="confirmDeleteTemplate">Löschen</button>
         </div>
       </div>
     </div>

--- a/school-login/views/teacher/teacher-grades.ejs
+++ b/school-login/views/teacher/teacher-grades.ejs
@@ -15,16 +15,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a class="is-active" href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -38,11 +38,11 @@
         <header class="teacher-main-header">
           <div>
             <p class="teacher-eyebrow">Klasse <%= classData.name %></p>
-            <h1>NotenÃ¼bersicht</h1>
+            <h1>Notenübersicht</h1>
             <p class="teacher-muted">Fach: <%= classData.subject %> - Rolle: Lehrer</p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/classes">ZurÃ¼ck</a>
+            <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
           </div>
         </header>
 
@@ -62,14 +62,14 @@
             class="form-input teacher-search-input"
             type="search"
             name="q"
-            placeholder="SchÃ¼ler nach Name oder E-Mail suchen"
+            placeholder="Schüler nach Name oder E-Mail suchen"
             value="<%= (search && search.q) || '' %>"
           >
           <select class="form-select teacher-search-select" name="status" aria-label="Filter">
             <option value="all" <%= (search && search.status) === 'all' ? 'selected' : '' %>>Alle</option>
             <option value="with_grades" <%= (search && search.status) === 'with_grades' ? 'selected' : '' %>>Mit Bewertungen</option>
             <option value="no_grades" <%= (search && search.status) === 'no_grades' ? 'selected' : '' %>>Ohne Bewertungen</option>
-            <option value="incomplete" <%= (search && search.status) === 'incomplete' ? 'selected' : '' %>>UnvollstÃ¤ndig</option>
+            <option value="incomplete" <%= (search && search.status) === 'incomplete' ? 'selected' : '' %>>Unvollständig</option>
           </select>
           <select class="form-select teacher-search-select" name="sort" aria-label="Sortierung">
             <option value="name_asc" <%= (search && search.sort) === 'name_asc' ? 'selected' : '' %>>Name A-Z</option>
@@ -86,8 +86,8 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">SchÃ¼ler und Noten</p>
-              <h3><%= students.length %> / <%= totalStudentCount %> SchÃ¼ler in dieser Klasse</h3>
+              <p class="teacher-eyebrow">Schüler und Noten</p>
+              <h3><%= students.length %> / <%= totalStudentCount %> Schüler in dieser Klasse</h3>
             </div>
             <% if (excludedStudentCount > 0) { %>
               <div class="teacher-meta-chip"><%= excludedStudentCount %> ausgeschlossen</div>
@@ -97,9 +97,9 @@
           <div class="grades-table-wrapper">
             <% if (students.length === 0) { %>
               <div class="teacher-empty">
-                <h4>Noch keine SchÃ¼ler</h4>
-                <p>FÃ¼ge zuerst SchÃ¼ler zur Klasse hinzu.</p>
-                <a class="btn btn-primary" href="/teacher/add-student/<%= classData.id %>">SchÃ¼ler hinzufÃ¼gen</a>
+                <h4>Noch keine Schüler</h4>
+                <p>Füge zuerst Schüler zur Klasse hinzu.</p>
+                <a class="btn btn-primary" href="/teacher/add-student/<%= classData.id %>">Schüler hinzufügen</a>
               </div>
             <% } else { %>
               <table class="grades-table">
@@ -112,7 +112,7 @@
                       <th>MA</th>
                     <% } %>
                     <th>Punkte (aktuell)</th>
-                    <th>âŒ€</th>
+                    <th>Schnitt</th>
                     <th>Aktionen</th>
                   </tr>
                 </thead>
@@ -205,10 +205,10 @@
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <input type="hidden" name="student_id" id="ma_student_id">
             <div class="modal-body">
-              <p>SchÃ¼ler: <strong id="ma_student_name"></strong></p>
+              <p>Schüler: <strong id="ma_student_name"></strong></p>
               <label for="ma_symbol">Benotung</label>
               <select id="ma_symbol" name="ma_symbol" required>
-                <option value="">Bitte wÃ¤hlen</option>
+                <option value="">Bitte wählen</option>
                 <% (participationSymbolOptions || []).forEach((symbolOption) => { %>
                   <option value="<%= symbolOption.value %>"><%= symbolOption.label %></option>
                 <% }) %>

--- a/school-login/views/teacher/teacher-settings.ejs
+++ b/school-login/views/teacher/teacher-settings.ejs
@@ -29,7 +29,7 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a class="is-active" href="/teacher/settings">Einstellungen</a>
@@ -44,18 +44,18 @@
       <section class="teacher-main">
         <header class="teacher-main-header">
           <div>
-            <p class="teacher-eyebrow">PersÃ¶nliches Schema</p>
+            <p class="teacher-eyebrow">Persönliches Schema</p>
             <h1>Bewertungseinstellungen</h1>
             <p class="teacher-muted">Gewichtung erfolgt nur in Punkten.</p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/classes">ZurÃ¼ck</a>
+            <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
           </div>
         </header>
 
         <% if (!setupComplete || showSetupFlow) { %>
           <div class="teacher-alert info">
-            Erste Konfiguration: Erstelle ein Profil. Dieses Profil wird automatisch fÃ¼r neue PrÃ¼fungen verwendet.
+            Erste Konfiguration: Erstelle ein Profil. Dieses Profil wird automatisch für neue Prüfungen verwendet.
           </div>
         <% } %>
 
@@ -102,7 +102,7 @@
                     <% } %>
                     <form class="inline delete-profile-form" method="POST" action="/teacher/settings/delete-profile/<%= profile.id %>" data-profile-name="<%= profile.name %>">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                      <button class="btn btn-danger btn-sm" type="button">LÃ¶schen</button>
+                      <button class="btn btn-danger btn-sm" type="button">Löschen</button>
                     </form>
                   </div>
                 </div>
@@ -114,8 +114,8 @@
         <% if (!showConfigForm) { %>
           <div class="teacher-card">
             <div class="teacher-empty">
-              <h4>Profil auswÃ¤hlen</h4>
-              <p>WÃ¤hle bei einem Profil "Bearbeiten" oder erstelle ein neues Profil.</p>
+              <h4>Profil auswählen</h4>
+              <p>Wähle bei einem Profil "Bearbeiten" oder erstelle ein neues Profil.</p>
             </div>
           </div>
         <% } %>
@@ -360,15 +360,15 @@
     <div id="deleteProfileModal" class="modal-overlay">
       <div class="modal-content">
         <div class="modal-header">
-          <h3>Profil lÃ¶schen</h3>
+          <h3>Profil löschen</h3>
         </div>
         <div class="modal-body">
-          <p>MÃ¶chtest du das Profil <strong id="deleteProfileName"></strong> wirklich lÃ¶schen?</p>
+          <p>Möchtest du das Profil <strong id="deleteProfileName"></strong> wirklich löschen?</p>
           <p class="teacher-muted">Wenn es aktiv ist, wird automatisch ein anderes Profil aktiv gesetzt.</p>
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" id="cancelDeleteProfile" type="button">Abbrechen</button>
-          <button class="btn btn-danger" id="confirmDeleteProfile" type="button">LÃ¶schen</button>
+          <button class="btn btn-danger" id="confirmDeleteProfile" type="button">Löschen</button>
         </div>
       </div>
     </div>

--- a/school-login/views/teacher/teacher-special-assessments.ejs
+++ b/school-login/views/teacher/teacher-special-assessments.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: `Lehrer â€“ Sonderleistungen (${classData.name})`,
+    title: `Lehrer - Sonderleistungen (${classData.name})`,
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -21,11 +21,16 @@
           "wunschpr-fung": "wunschprufung"
         })[
           String(value || "")
-            .replace(/ÃƒÂ¤/g, "Ã¤")
-            .replace(/ÃƒÂ¶/g, "Ã¶")
-            .replace(/ÃƒÂ¼/g, "Ã¼")
-            .replace(/ÃƒÅ¸/g, "ÃŸ")
-            .replace(/Ã‚/g, "")
+            .replace(/\u00c3\u0192\u00c2\u00a4/g, "ä")
+            .replace(/\u00c3\u0192\u00c2\u00b6/g, "ö")
+            .replace(/\u00c3\u0192\u00c2\u00bc/g, "ü")
+            .replace(/\u00c3\u0192\u00c5\u00b8/g, "ß")
+            .replace(/\u00c3\u201a/g, "")
+            .replace(/\u00c3\u00a4/g, "ä")
+            .replace(/\u00c3\u00b6/g, "ö")
+            .replace(/\u00c3\u00bc/g, "ü")
+            .replace(/\u00c3\u0178/g, "ß")
+            .replace(/\u00c2/g, "")
             .normalize("NFD")
             .replace(/[\u0300-\u036f]/g, "")
             .toLowerCase()
@@ -33,11 +38,16 @@
             .replace(/^-+|-+$/g, "")
         ] ||
         String(value || "")
-          .replace(/ÃƒÂ¤/g, "Ã¤")
-          .replace(/ÃƒÂ¶/g, "Ã¶")
-          .replace(/ÃƒÂ¼/g, "Ã¼")
-          .replace(/ÃƒÅ¸/g, "ÃŸ")
-          .replace(/Ã‚/g, "")
+          .replace(/\u00c3\u0192\u00c2\u00a4/g, "ä")
+            .replace(/\u00c3\u0192\u00c2\u00b6/g, "ö")
+            .replace(/\u00c3\u0192\u00c2\u00bc/g, "ü")
+            .replace(/\u00c3\u0192\u00c5\u00b8/g, "ß")
+            .replace(/\u00c3\u201a/g, "")
+            .replace(/\u00c3\u00a4/g, "ä")
+            .replace(/\u00c3\u00b6/g, "ö")
+            .replace(/\u00c3\u00bc/g, "ü")
+            .replace(/\u00c3\u0178/g, "ß")
+            .replace(/\u00c2/g, "")
           .normalize("NFD")
           .replace(/[\u0300-\u036f]/g, "")
           .toLowerCase()
@@ -50,16 +60,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">SchÃ¼ler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a class="is-active" href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -74,15 +84,15 @@
           <div>
             <p class="teacher-eyebrow">Klasse <%= classData.name %></p>
             <h1>Sonderleistungen</h1>
-            <p class="teacher-muted">Fach: <%= classData.subject %> Â· Individuelle Zusatzbewertungen</p>
+            <p class="teacher-muted">Fach: <%= classData.subject %> · Individuelle Zusatzbewertungen</p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/classes">ZurÃ¼ck</a>
+            <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
           </div>
         </header>
 
         <div class="teacher-alert info">
-          Sonderleistungen nutzen Punkte und fliessen zusÃ¤tzlich in die Gesamtnote ein.
+          Sonderleistungen nutzen Punkte und fließen zusätzlich in die Gesamtnote ein.
         </div>
 
         <div class="teacher-card">
@@ -100,9 +110,9 @@
           <form class="teacher-form" method="POST" action="/teacher/special-assessments/<%= classData.id %>">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
 
-            <label for="student_id">SchÃ¼ler *</label>
+            <label for="student_id">Schüler *</label>
             <select id="student_id" name="student_id" required>
-              <option value="">-- SchÃ¼ler wÃ¤hlen --</option>
+              <option value="">-- Schüler wählen --</option>
               <% students.forEach(student => { %>
                 <option value="<%= student.id %>" <%= String(formData.student_id) === String(student.id) ? 'selected' : '' %> <%= student.is_excluded ? 'disabled' : '' %>>
                   <%= student.name %> (<%= student.email %>)<%= student.is_excluded ? ' - ausgeschlossen' : '' %>
@@ -112,20 +122,20 @@
 
             <label for="type">Typ *</label>
             <select id="type" name="type" required>
-              <option value="">-- Typ wÃ¤hlen --</option>
+              <option value="">-- Typ wählen --</option>
               <% specialTypes.forEach(typeOption => { %>
                 <option value="<%= typeOption %>" <%= formData.type === typeOption ? 'selected' : '' %>>
                   <%= typeOption %>
                 </option>
               <% }) %>
             </select>
-            <small class="form-hint">FÃ¼r "Benutzerdefiniert" ist eine eigene Bezeichnung Pflicht.</small>
+            <small class="form-hint">Für "Benutzerdefiniert" ist eine eigene Bezeichnung Pflicht.</small>
 
             <label for="name">Bezeichnung</label>
-            <input type="text" id="name" name="name" value="<%= formData.name || '' %>" placeholder="z.B. PrÃ¤sentation Modul 2">
+            <input type="text" id="name" name="name" value="<%= formData.name || '' %>" placeholder="z.B. Präsentation Modul 2">
 
             <label for="description">Beschreibung</label>
-            <textarea id="description" name="description" rows="2" placeholder="Kurzbeschreibung oder Wunsch des SchÃ¼lers"><%= formData.description || '' %></textarea>
+            <textarea id="description" name="description" rows="2" placeholder="Kurzbeschreibung oder Wunsch des Schülers"><%= formData.description || '' %></textarea>
 
             <label for="weight">Gewichtung (ab 0 <%= weightUnit %>) *</label>
             <input type="number" id="weight" name="weight" min="0" step="0.5" required value="<%= formData.weight || '' %>">
@@ -135,7 +145,7 @@
 
             <div class="teacher-form-actions">
               <button class="btn btn-primary" type="submit">Sonderleistung speichern</button>
-              <a class="btn btn-secondary" href="/teacher/grades/<%= classData.id %>">ZurÃ¼ck zu Noten</a>
+              <a class="btn btn-secondary" href="/teacher/grades/<%= classData.id %>">Zurück zu Noten</a>
             </div>
           </form>
         </div>
@@ -143,17 +153,17 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">Ãœbersicht</p>
+              <p class="teacher-eyebrow">Übersicht</p>
               <h3>Sonderleistungen der Klasse</h3>
             </div>
-            <div class="teacher-meta-chip"><%= assessments.length %> EintrÃ¤ge</div>
+            <div class="teacher-meta-chip"><%= assessments.length %> Einträge</div>
           </div>
 
           <div class="grades-list">
             <% if (assessments.length === 0) { %>
               <div class="teacher-empty">
                 <h4>Noch keine Sonderleistungen</h4>
-                <p>Lege individuelle Bewertungen fÃ¼r einzelne SchÃ¼ler an.</p>
+                <p>Lege individuelle Bewertungen für einzelne Schüler an.</p>
               </div>
             <% } else { %>
               <% assessments.forEach(assessment => { %>
@@ -164,7 +174,7 @@
                       <h4 class="grade-item-title"><%= assessment.name %></h4>
                       <span class="weight-badge-small"><%= assessment.weight %> <%= weightUnit %></span>
                       <span class="grade-date"><%= new Date(assessment.created_at).toLocaleDateString('de-DE') %></span>
-                      <div class="teacher-muted">SchÃ¼ler: <%= assessment.student_name %></div>
+                      <div class="teacher-muted">Schüler: <%= assessment.student_name %></div>
                       <% if (assessment.is_subject_excluded) { %>
                         <div class="teacher-excluded-note"><span class="teacher-exclusion-badge">Ausgeschlossen</span> Nur historisch sichtbar</div>
                       <% } %>
@@ -173,7 +183,7 @@
                       <span class="grade-badge grade-<%= Math.round(assessment.grade) %>"><%= assessment.grade %></span>
                       <form class="inline delete-special-assessment-form" method="POST" action="/teacher/delete-special-assessment/<%= classData.id %>/<%= assessment.id %>" data-assessment-name="<%= assessment.name %>">
                         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                        <button class="btn btn-danger btn-sm" type="button">LÃ¶schen</button>
+                        <button class="btn btn-danger btn-sm" type="button">Löschen</button>
                       </form>
                     </div>
                   </div>
@@ -191,15 +201,15 @@
     <div id="deleteSpecialAssessmentModal" class="modal-overlay">
       <div class="modal-content">
         <div class="modal-header">
-          <h3>Sonderleistung lÃ¶schen</h3>
+          <h3>Sonderleistung löschen</h3>
         </div>
         <div class="modal-body">
-          <p>MÃ¶chtest du die Sonderleistung <strong id="deleteSpecialAssessmentName"></strong> wirklich lÃ¶schen?</p>
-          <p class="teacher-muted">Diese Aktion kann nicht rÃ¼ckgÃ¤ngig gemacht werden.</p>
+          <p>Möchtest du die Sonderleistung <strong id="deleteSpecialAssessmentName"></strong> wirklich löschen?</p>
+          <p class="teacher-muted">Diese Aktion kann nicht rückgängig gemacht werden.</p>
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" id="cancelDeleteSpecialAssessment">Abbrechen</button>
-          <button class="btn btn-danger" id="confirmDeleteSpecialAssessment">LÃ¶schen</button>
+          <button class="btn btn-danger" id="confirmDeleteSpecialAssessment">Löschen</button>
         </div>
       </div>
     </div>
@@ -249,4 +259,3 @@
 <% } };
 %>
 <%- include('../layout', page) %>
-

--- a/school-login/views/teacher/teacher-student-grade-details.ejs
+++ b/school-login/views/teacher/teacher-student-grade-details.ejs
@@ -17,15 +17,15 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">SchÃ¼ler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">PrÃ¼fungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -50,7 +50,7 @@
             </p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/student-grades/<%= classData.id %>/<%= student.id %>">ZurÃ¼ck zu Notendetails</a>
+            <a class="btn btn-secondary" href="/teacher/student-grades/<%= classData.id %>/<%= student.id %>">Zurück zu Notendetails</a>
           </div>
         </header>
 
@@ -75,12 +75,12 @@
             </div>
           <% } %>
           <p class="teacher-muted">
-            Einbezogene EintrÃ¤ge: <strong><%= summary.included_count %></strong> |
-            Ausgeschlossene EintrÃ¤ge: <strong><%= summary.excluded_count %></strong> |
+            Einbezogene Einträge: <strong><%= summary.included_count %></strong> |
+            Ausgeschlossene Einträge: <strong><%= summary.excluded_count %></strong> |
             Referenzschnitt (System): <strong><%= summary.reference_average != null ? summary.reference_average : "-" %></strong>
           </p>
           <p class="teacher-muted">
-            Punkte (aktuell mÃ¶glich):
+            Punkte (aktuell möglich):
             <strong>
               <%= summary.points_achieved_total != null ? summary.points_achieved_total : "-" %>/<%= summary.points_max_total != null ? summary.points_max_total : "-" %>
             </strong>
@@ -174,7 +174,7 @@
           <div class="teacher-card-header">
             <div>
               <p class="teacher-eyebrow">Rohdaten</p>
-              <h3>Alle bewerteten EintrÃ¤ge mit Berechnungsdaten</h3>
+              <h3>Alle bewerteten Einträge mit Berechnungsdaten</h3>
             </div>
             <div class="teacher-actions-inline">
               <a class="btn btn-secondary btn-sm" href="/teacher/student-grades/<%= classData.id %>/<%= student.id %>/details?format=csv_raw">.csv</a>
@@ -190,7 +190,7 @@
                   <th>Bezeichnung</th>
                   <th>Kategorie</th>
                   <th>Erfasst</th>
-                  <th>PrÃ¼fungsdatum</th>
+                  <th>Prüfungsdatum</th>
                   <th>Note</th>
                   <th>Gewicht roh</th>
                   <th>Gewicht effektiv</th>
@@ -297,7 +297,7 @@
           <div class="teacher-card-header">
             <div>
               <p class="teacher-eyebrow">Offene Vorlagen</p>
-              <h3>Noch nicht benotete PrÃ¼fungen</h3>
+              <h3>Noch nicht benotete Prüfungen</h3>
             </div>
             <div class="teacher-meta-chip"><%= openTemplates.length %> offen</div>
           </div>

--- a/school-login/views/teacher/teacher-student-grades.ejs
+++ b/school-login/views/teacher/teacher-student-grades.ejs
@@ -21,11 +21,16 @@
           "wunschpr-fung": "wunschprufung"
         })[
           String(value || "")
-            .replace(/Ã¤/g, "ä")
-            .replace(/Ã¶/g, "ö")
-            .replace(/Ã¼/g, "ü")
-            .replace(/ÃŸ/g, "ß")
-            .replace(/Â/g, "")
+            .replace(/\u00c3\u0192\u00c2\u00a4/g, "ä")
+            .replace(/\u00c3\u0192\u00c2\u00b6/g, "ö")
+            .replace(/\u00c3\u0192\u00c2\u00bc/g, "ü")
+            .replace(/\u00c3\u0192\u00c5\u00b8/g, "ß")
+            .replace(/\u00c3\u201a/g, "")
+            .replace(/\u00c3\u00a4/g, "ä")
+            .replace(/\u00c3\u00b6/g, "ö")
+            .replace(/\u00c3\u00bc/g, "ü")
+            .replace(/\u00c3\u0178/g, "ß")
+            .replace(/\u00c2/g, "")
             .normalize("NFD")
             .replace(/[\u0300-\u036f]/g, "")
             .toLowerCase()
@@ -33,11 +38,16 @@
             .replace(/^-+|-+$/g, "")
         ] ||
         String(value || "")
-          .replace(/Ã¤/g, "ä")
-          .replace(/Ã¶/g, "ö")
-          .replace(/Ã¼/g, "ü")
-          .replace(/ÃŸ/g, "ß")
-          .replace(/Â/g, "")
+          .replace(/\u00c3\u0192\u00c2\u00a4/g, "ä")
+            .replace(/\u00c3\u0192\u00c2\u00b6/g, "ö")
+            .replace(/\u00c3\u0192\u00c2\u00bc/g, "ü")
+            .replace(/\u00c3\u0192\u00c5\u00b8/g, "ß")
+            .replace(/\u00c3\u201a/g, "")
+            .replace(/\u00c3\u00a4/g, "ä")
+            .replace(/\u00c3\u00b6/g, "ö")
+            .replace(/\u00c3\u00bc/g, "ü")
+            .replace(/\u00c3\u0178/g, "ß")
+            .replace(/\u00c2/g, "")
           .normalize("NFD")
           .replace(/[\u0300-\u036f]/g, "")
           .toLowerCase()
@@ -55,7 +65,7 @@
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
@@ -137,7 +147,7 @@
             </button>
           </div>
           <% if ((wishGradeRows || []).length === 0) { %>
-            <p class="teacher-muted"><%= student.is_excluded ? 'Keine aktive Berechnung, weil der Schueler in diesem Fach ausgeschlossen ist.' : 'Noch keine gewichteten Einträge vorhanden.' %></p>
+            <p class="teacher-muted"><%= student.is_excluded ? 'Keine aktive Berechnung, weil der Schüler in diesem Fach ausgeschlossen ist.' : 'Noch keine gewichteten Einträge vorhanden.' %></p>
           <% } else { %>
             <p class="teacher-muted">Der Rechner berücksichtigt Noten und Mitarbeit aus der Gesamtnote.</p>
           <% } %>
@@ -162,7 +172,7 @@
           <% } else if ((participationEntries || []).length === 0) { %>
             <div class="teacher-empty">
               <h4><%= student.is_excluded ? 'Keine aktive Mitarbeit' : 'Noch keine Mitarbeit' %></h4>
-              <p><%= student.is_excluded ? 'Der Schueler ist in diesem Fach ausgeschlossen. Historische MA-Eintraege wuerden hier erscheinen.' : 'In der Notenübersicht kannst du mit dem MA-Button Einträge erfassen.' %></p>
+              <p><%= student.is_excluded ? 'Der Schüler ist in diesem Fach ausgeschlossen. Historische MA-Einträge würden hier erscheinen.' : 'In der Notenübersicht kannst du mit dem MA-Button Einträge erfassen.' %></p>
             </div>
           <% } else { %>
             <div class="grades-table-wrapper">
@@ -214,7 +224,7 @@
             <% if (grades.length === 0) { %>
               <div class="teacher-empty">
                 <h4><%= student.is_excluded ? 'Keine aktiven Bewertungen' : 'Noch keine Noten' %></h4>
-                <p><%= student.is_excluded ? 'Der Schueler ist in diesem Fach ausgeschlossen. Historische Eintraege wuerden hier erscheinen.' : 'Füge die erste Note für diesen Schüler hinzu.' %></p>
+                <p><%= student.is_excluded ? 'Der Schüler ist in diesem Fach ausgeschlossen. Historische Einträge würden hier erscheinen.' : 'Füge die erste Note für diesen Schüler hinzu.' %></p>
                 <% if (!student.is_excluded) { %>
                   <a class="btn btn-primary" href="/teacher/add-grade/<%= classData.id %>/<%= student.id %>">Bewertung hinzufügen</a>
                 <% } %>
@@ -298,7 +308,7 @@
                           <% grade.messages.forEach(message => { %>
                             <div class="teacher-message-item">
                               <div class="teacher-message-bubble student">
-                                <p class="teacher-message-author"><%= student.email || 'Schueler' %></p>
+                                <p class="teacher-message-author"><%= student.email || 'Schüler' %></p>
                                 <p><%= message.student_message %></p>
                                 <small class="teacher-muted"><%= new Date(message.created_at).toLocaleString('de-DE') %></small>
                               </div>
@@ -312,7 +322,7 @@
                                 <form class="teacher-form teacher-reply-form" method="POST" action="/teacher/students/<%= classData.id %>/messages/<%= message.id %>/reply">
                                   <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                                   <label for="reply-grade-<%= grade.id %>-<%= message.id %>">Antwort</label>
-                                  <textarea id="reply-grade-<%= grade.id %>-<%= message.id %>" name="reply" rows="3" maxlength="1000" required placeholder="Antwort an den Schueler..."></textarea>
+                                  <textarea id="reply-grade-<%= grade.id %>-<%= message.id %>" name="reply" rows="3" maxlength="1000" required placeholder="Antwort an den Schüler..."></textarea>
                                   <div class="teacher-form-actions">
                                     <button class="btn btn-primary" type="submit">Antwort senden</button>
                                   </div>
@@ -369,7 +379,7 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button class="btn btn-secondary" type="button" id="closeWishGradeModal">Schliessen</button>
+          <button class="btn btn-secondary" type="button" id="closeWishGradeModal">Schließen</button>
         </div>
       </div>
     </div>

--- a/school-login/views/teacher/teacher-students.ejs
+++ b/school-login/views/teacher/teacher-students.ejs
@@ -1,6 +1,6 @@
 ﻿<%
   const page = {
-    title: `Lehrer - Schueler (${classData.name})`,
+    title: `Lehrer - Schüler (${classData.name})`,
     headerTitle: 'Lehrerbereich',
     styles: ['/css/teacher-pages.css'],
     scripts: ['/js/app.js'],
@@ -14,16 +14,16 @@
 
         <div class="app-nav">
           <div class="nav-section">
-            <div class="nav-section-title">MenÃ¼</div>
+            <div class="nav-section-title">Menü</div>
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <a href="/teacher/settings">Einstellungen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a class="is-active" href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a class="is-active" href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="<%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">Pruefungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -37,12 +37,12 @@
         <header class="teacher-main-header">
           <div>
             <p class="teacher-eyebrow">Klasse <%= classData.name %></p>
-            <h1>Schueler verwalten</h1>
+            <h1>Schüler verwalten</h1>
             <p class="teacher-muted">Fach: <%= classData.subject %> - Rolle: Lehrer</p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-primary" href="/teacher/add-student/<%= classData.id %>">+ Schueler hinzufuegen</a>
-            <a class="btn btn-secondary" href="/teacher/classes">Zurueck</a>
+            <a class="btn btn-primary" href="/teacher/add-student/<%= classData.id %>">+ Schüler hinzufügen</a>
+            <a class="btn btn-secondary" href="/teacher/classes">Zurück</a>
           </div>
         </header>
 
@@ -51,7 +51,7 @@
             class="form-input teacher-search-input"
             type="search"
             name="q"
-            placeholder="SchÃ¼ler nach Name oder E-Mail suchen"
+            placeholder="Schüler nach Name oder E-Mail suchen"
             value="<%= (search && search.q) || '' %>"
           >
           <select class="form-select teacher-search-select" name="sort" aria-label="Sortierung">
@@ -67,8 +67,8 @@
         <div class="teacher-card">
           <div class="teacher-card-header">
             <div>
-              <p class="teacher-eyebrow">Schueler</p>
-              <h3><%= students.length %> / <%= totalStudentCount %> Schueler in dieser Klasse</h3>
+              <p class="teacher-eyebrow">Schüler</p>
+              <h3><%= students.length %> / <%= totalStudentCount %> Schüler in dieser Klasse</h3>
             </div>
             <% if (excludedStudentCount > 0) { %>
               <div class="teacher-meta-chip"><%= excludedStudentCount %> ausgeschlossen</div>
@@ -78,15 +78,15 @@
           <div class="teacher-list">
             <% if (students.length === 0) { %>
               <div class="teacher-empty">
-                <h4>Noch keine Schueler</h4>
-                <p>Fuege Schueler hinzu, um die Klasse zu fuellen.</p>
-                <a class="btn btn-primary" href="/teacher/add-student/<%= classData.id %>">Schueler hinzufuegen</a>
+                <h4>Noch keine Schüler</h4>
+                <p>Füge Schüler hinzu, um die Klasse zu füllen.</p>
+                <a class="btn btn-primary" href="/teacher/add-student/<%= classData.id %>">Schüler hinzufügen</a>
               </div>
             <% } else { %>
               <% students.forEach(student => { %>
                 <div class="teacher-student-card <%= student.is_excluded ? 'is-excluded' : '' %>">
                   <div>
-                    <p class="teacher-eyebrow">Schueler</p>
+                    <p class="teacher-eyebrow">Schüler</p>
                     <h4><%= student.name %></h4>
                     <p class="teacher-muted"><%= student.email %></p>
                     <% if (student.is_excluded) { %>
@@ -123,10 +123,10 @@
     <div id="deleteModal" class="modal-overlay">
       <div class="modal-content">
         <div class="modal-header">
-          <h3>Schueler entfernen</h3>
+          <h3>Schüler entfernen</h3>
         </div>
         <div class="modal-body">
-          <p>Moechtest du den Schueler <strong id="deleteStudentName"></strong> wirklich aus der Klasse entfernen?</p>
+          <p>Möchtest du den Schüler <strong id="deleteStudentName"></strong> wirklich aus der Klasse entfernen?</p>
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" id="cancelDelete">Abbrechen</button>

--- a/school-login/views/teacher/teacher-test-questions.ejs
+++ b/school-login/views/teacher/teacher-test-questions.ejs
@@ -18,11 +18,11 @@
             <a href="/teacher/classes">Fächer</a>
             <a href="/teacher/create-class">Fach erstellen</a>
             <div class="nav-section-title">Klasse: <%= classData.name %> / <%= classData.subject %></div>
-            <a href="/teacher/students/<%= classData.id %>">Schueler</a>
+            <a href="/teacher/students/<%= classData.id %>">Schüler</a>
             <a class="is-active <%= (typeof openMessageCount !== 'undefined' && openMessageCount > 0) ? 'is-alert' : '' %>" href="/teacher/test-questions/<%= classData.id %>">Fragen zu Tests<% if (typeof openMessageCount !== 'undefined' && openMessageCount > 0) { %><span class="nav-notification-badge"><%= openMessageCount %></span><% } %></a>
             <a href="/teacher/grades/<%= classData.id %>">Noten</a>
             <a href="/teacher/special-assessments/<%= classData.id %>">Sonderleistungen</a>
-            <a href="/teacher/grade-templates/<%= classData.id %>">Pruefungen</a>
+            <a href="/teacher/grade-templates/<%= classData.id %>">Prüfungen</a>
             <a href="/teacher/class-statistics/<%= classData.id %>">Statistiken</a>
             <form class="logout-form" method="POST" action="/logout">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -35,12 +35,12 @@
       <section class="teacher-main teacher-test-questions-page">
         <header class="teacher-main-header teacher-main-header-compact">
           <div>
-            <p class="teacher-eyebrow">Rueckgaben</p>
+            <p class="teacher-eyebrow">Rückgaben</p>
             <h1>Fragen zu Tests</h1>
             <p class="teacher-muted">Klasse: <%= classData.name %> - Fach: <%= classData.subject %></p>
           </div>
           <div class="teacher-actions-inline">
-            <a class="btn btn-secondary" href="/teacher/students/<%= classData.id %>">Zurueck zu Schueler</a>
+            <a class="btn btn-secondary" href="/teacher/students/<%= classData.id %>">Zurück zu Schüler</a>
           </div>
         </header>
 
@@ -59,7 +59,7 @@
           <% if (!messageThreads || messageThreads.length === 0) { %>
             <div class="teacher-empty">
               <h4>Keine Fragen vorhanden</h4>
-              <p>Schuelerfragen zu Rueckgaben erscheinen hier.</p>
+              <p>Schülerfragen zu Rückgaben erscheinen hier.</p>
             </div>
           <% } else { %>
             <form class="teacher-search-form teacher-thread-controls" id="thread-filter-form" role="search" aria-label="Nachrichten filtern" onsubmit="return false;">
@@ -69,7 +69,7 @@
                   class="form-input teacher-search-input"
                   type="search"
                   id="thread-search"
-                  placeholder="Schueler, E-Mail, Test oder Nachricht suchen"
+                  placeholder="Schüler, E-Mail, Test oder Nachricht suchen"
                 >
               </div>
               <div class="teacher-thread-filter-field">
@@ -84,7 +84,7 @@
                 <label class="teacher-filter-label" for="thread-sort-filter">Sortierung</label>
                 <select class="form-select teacher-search-select" id="thread-sort-filter" aria-label="Sortierung">
                   <option value="latest_desc">Neueste zuerst</option>
-                  <option value="latest_asc">Aelteste zuerst</option>
+                  <option value="latest_asc">Älteste zuerst</option>
                   <option value="open_first">Offene zuerst</option>
                   <option value="student_asc">Name A-Z</option>
                   <option value="student_desc">Name Z-A</option>
@@ -124,12 +124,12 @@
                         </p>
                         <div class="teacher-thread-meta">
                           <span><%= thread.messages.length %> Nachricht<%= thread.messages.length === 1 ? '' : 'en' %></span>
-                          <span>Letzte Aktivitaet: <%= new Date(thread.latest_at).toLocaleString('de-DE') %></span>
+                          <span>Letzte Aktivität: <%= new Date(thread.latest_at).toLocaleString('de-DE') %></span>
                         </div>
                       </div>
                       <div class="teacher-thread-summary-right">
                         <% if (thread.student_closed_at) { %>
-                          <span class="teacher-meta-chip teacher-meta-chip-status-student-closed">vom Schueler geschlossen</span>
+                          <span class="teacher-meta-chip teacher-meta-chip-status-student-closed">vom Schüler geschlossen</span>
                         <% } else if (hasOpenMessages) { %>
                           <span class="teacher-meta-chip teacher-meta-chip-status-open"><%= openMessages %> offen</span>
                         <% } else { %>
@@ -140,8 +140,8 @@
 
                     <div class="teacher-collapsible-body">
                       <div class="teacher-thread-body-header">
-                        <small class="teacher-muted">Letzte Aktivitaet: <%= new Date(thread.latest_at).toLocaleString('de-DE') %></small>
-                        <a class="btn btn-secondary btn-sm" href="/teacher/student-grades/<%= classData.id %>/<%= thread.student_id %>">Zum Schueler-Detail</a>
+                        <small class="teacher-muted">Letzte Aktivität: <%= new Date(thread.latest_at).toLocaleString('de-DE') %></small>
+                        <a class="btn btn-secondary btn-sm" href="/teacher/student-grades/<%= classData.id %>/<%= thread.student_id %>">Zum Schüler-Detail</a>
                       </div>
                       <% if (thread.student_closed_at) { %>
                         <div class="teacher-message-bubble system">
@@ -152,7 +152,7 @@
                       <% } %>
                       <% thread.messages.forEach(message => { %>
                         <div class="teacher-message-bubble student">
-                          <p class="teacher-message-author"><%= thread.student_email || 'Schueler' %></p>
+                          <p class="teacher-message-author"><%= thread.student_email || 'Schüler' %></p>
                           <p><%= message.student_message %></p>
                           <small class="teacher-muted"><%= new Date(message.created_at).toLocaleString('de-DE') %></small>
                         </div>
@@ -169,7 +169,7 @@
                           <form class="teacher-form teacher-reply-form" method="POST" action="/teacher/students/<%= classData.id %>/messages/<%= message.id %>/reply">
                             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                             <label for="reply-<%= message.id %>">Antwort</label>
-                            <textarea id="reply-<%= message.id %>" name="reply" rows="3" maxlength="1000" required placeholder="Antwort an den Schueler..."></textarea>
+                            <textarea id="reply-<%= message.id %>" name="reply" rows="3" maxlength="1000" required placeholder="Antwort an den Schüler..."></textarea>
                             <div class="teacher-form-actions">
                               <button class="btn btn-primary" type="submit">Antwort senden</button>
                             </div>


### PR DESCRIPTION
## Changelog

- Deutsche Umlaute in sichtbaren Texten korrigiert, z.B. `Schueler` zu `Schüler`, `Pruefung` zu `Prüfung`, `Rueckgabe` zu `Rückgabe`.
- Kaputte Encoding-Zeichen wie `Ã¼`, `Â·`, `SchǬler` und ähnliche Mojibake-Reste bereinigt.
- Betroffene Admin-, Teacher- und Student-Views sowie Meldungen, CSV-Header und UI-Texte angepasst.
- Technische Aliase und CSS-/Mapping-Schlüssel wie `hausuebung`, `wunschpruefung`, `praesentation` und `schueler` bewusst unverändert gelassen.
- EJS-Templates nach der Bereinigung repariert und erfolgreich kompiliert.
- Syntaxchecks für geänderte JS-Dateien erfolgreich durchgeführt.
- Hinweis: Bestehende Integrationstests schlagen weiterhin bei alten JSON-/404-Testannahmen fehl, nicht wegen der Umlaut-Bereinigung.
