### PR TITLE
Styleupdate

### DIFF
--- a/school-login/public/css/admin.css
+++ b/school-login/public/css/admin.css
@@ -19,13 +19,6 @@ body.page-admin-edit {
   border-radius: 12px;
   border: 1px solid rgba(226,232,240,0.75);
   box-shadow: 0 10px 25px rgba(37, 99, 235, 0.06);
-  transition: all 0.2s ease;
-}
-
-.admin-card:hover,
-.admin-card-narrow:hover {
-  box-shadow: 0 14px 36px rgba(37, 99, 235, 0.09);
-  border-color: rgba(96,165,250,0.9);
 }
 
 .admin-heading-spaced {

--- a/school-login/public/css/student-dashboard.css
+++ b/school-login/public/css/student-dashboard.css
@@ -88,6 +88,21 @@ body.page-student {
   box-shadow: var(--student-shadow);
 }
 
+.page-student #tasks > .card,
+.page-student #returns > .card,
+.page-student #requests > .card,
+.page-student #archive > .card {
+  transition: none;
+}
+
+.page-student #tasks > .card:hover,
+.page-student #returns > .card:hover,
+.page-student #requests > .card:hover,
+.page-student #archive > .card:hover {
+  border-color: var(--student-border);
+  box-shadow: var(--student-shadow);
+}
+
 header.dashboard-hero {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;


### PR DESCRIPTION
•Removed the hover animation and blue border effect from the main content cards on /student/tasks, /student/returns, /student/requests, and /student/archive.
•Kept the student cards visually unchanged in their default state; they no longer react when hovered.
•Removed hover effects from the large admin cards as well, including the pages /admin/classes, /admin/classes/new, /admin/assignments, /admin/users, and /admin/audit-logs.
•Preserved the normal admin card shadow, but disabled hover-based shadow/border changes so the large cards stay static on mouseove