### PR TITLE
big update for admin assignments tab

### DIFF
--- a/school-login/controllers/assignmentController.js
+++ b/school-login/controllers/assignmentController.js
@@ -2,6 +2,9 @@ const assignmentModel = require("../models/assignmentModel");
 const { ensureSubjectIdByName } = require("../utils/subjects");
 const { getDisplayName } = require("../utils/userDisplay");
 
+const TEACHER_PAGE_SIZE = 50;
+const UNASSIGNED_CLASS_LABEL = "Keine Klasse";
+
 function toUniqueIds(values) {
   const rawValues = Array.isArray(values) ? values : [values].filter(Boolean);
   return [...new Set(
@@ -12,7 +15,9 @@ function toUniqueIds(values) {
 }
 
 function buildGroupKey(classId, subjectId) {
-  return `${Number(classId)}:${Number(subjectId)}`;
+  const normalizedClassId = classId == null || classId === "" ? "none" : Number(classId);
+  const normalizedSubjectId = subjectId == null || subjectId === "" ? "none" : Number(subjectId);
+  return `${normalizedClassId}:${normalizedSubjectId}`;
 }
 
 function groupAssignmentRows(rows) {
@@ -26,10 +31,42 @@ function groupAssignmentRows(rows) {
 }
 
 function addDisplayNames(teachers) {
-  return teachers.map((t) => ({
-    ...t,
-    display_name: getDisplayName({ email: t.email }) || t.email
+  return teachers.map((teacher) => ({
+    ...teacher,
+    display_name: getDisplayName({ email: teacher.email }) || teacher.email
   }));
+}
+
+function normalizePositiveId(value) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function normalizeSearchQuery(value) {
+  return String(value || "").trim().slice(0, 100);
+}
+
+function normalizeLimit(value, fallback = TEACHER_PAGE_SIZE) {
+  return Math.max(Math.min(Number(value) || fallback, 200), 1);
+}
+
+function normalizeOffset(value) {
+  return Math.max(Number(value) || 0, 0);
+}
+
+function compareAssignmentGroups(a, b) {
+  const aHasClass = Number.isInteger(Number(a.class_id)) && Number(a.class_id) > 0;
+  const bHasClass = Number.isInteger(Number(b.class_id)) && Number(b.class_id) > 0;
+  if (aHasClass !== bHasClass) return aHasClass ? -1 : 1;
+
+  const classCompare = String(a.class_name || "").localeCompare(String(b.class_name || ""), "de", {
+    sensitivity: "base"
+  });
+  if (classCompare !== 0) return classCompare;
+
+  return String(a.subject_name || "").localeCompare(String(b.subject_name || ""), "de", {
+    sensitivity: "base"
+  });
 }
 
 function consumeFlash(req) {
@@ -51,9 +88,11 @@ function flashAndRedirect(req, res, url, { message, error, formData } = {}) {
 
 async function renderAssignmentList(req, res, next) {
   try {
-    const [groups, rows] = await Promise.all([
+    const [groups, rows, subjects, classes] = await Promise.all([
       assignmentModel.listAssignmentGroups(),
-      assignmentModel.listAssignmentRows()
+      assignmentModel.listAssignmentRows(),
+      assignmentModel.listSubjects(),
+      assignmentModel.listClasses()
     ]);
 
     const rowMap = groupAssignmentRows(
@@ -63,10 +102,37 @@ async function renderAssignmentList(req, res, next) {
       }))
     );
 
-    const assignments = groups.map((group) => ({
-      ...group,
-      rows: rowMap.get(buildGroupKey(group.class_id, group.subject_id)) || []
-    }));
+    const assignedSubjectIds = new Set(
+      groups
+        .map((group) => Number(group.subject_id))
+        .filter((subjectId) => Number.isInteger(subjectId) && subjectId > 0)
+    );
+    const classSubjectIds = new Set(
+      classes
+        .map((classRow) => Number(classRow.subject_id))
+        .filter((subjectId) => Number.isInteger(subjectId) && subjectId > 0)
+    );
+
+    const subjectOnlyGroups = subjects
+      .filter((subject) => {
+        const subjectId = Number(subject.id);
+        return !assignedSubjectIds.has(subjectId) && !classSubjectIds.has(subjectId);
+      })
+      .map((subject) => ({
+        class_id: null,
+        subject_id: subject.id,
+        class_name: UNASSIGNED_CLASS_LABEL,
+        subject_name: subject.name,
+        teacher_names: "",
+        teacher_count: 0
+      }));
+
+    const assignments = [...groups, ...subjectOnlyGroups]
+      .map((group) => ({
+        ...group,
+        rows: rowMap.get(buildGroupKey(group.class_id, group.subject_id)) || []
+      }))
+      .sort(compareAssignmentGroups);
 
     const flash = consumeFlash(req);
 
@@ -86,46 +152,57 @@ async function renderAssignmentList(req, res, next) {
 
 async function renderNewAssignmentForm(req, res, next) {
   try {
-    const [classes, subjects, teachers, assignmentRows] = await Promise.all([
-      assignmentModel.listClasses(),
-      assignmentModel.listSubjects(),
-      assignmentModel.listTeachers(),
-      assignmentModel.listAssignmentRows()
-    ]);
+    const classes = await assignmentModel.listClasses();
+    const requestedClassId = normalizePositiveId(req.query.class);
+    const requestedSubjectId = normalizePositiveId(req.query.subject);
+    const explicitCreateSubjectMode = String(req.query.create_subject || "").trim() === "1";
+    const initialClassId =
+      requestedClassId && classes.some((entry) => Number(entry.id) === requestedClassId)
+        ? requestedClassId
+        : null;
 
-    const teachersWithNames = addDisplayNames(teachers);
+    let classSubjects = [];
+    if (initialClassId) {
+      classSubjects = await assignmentModel.listClassSubjects(initialClassId);
+    }
 
-    const requestedClassId = Number(req.query.class) || null;
-    const requestedSubjectId = Number(req.query.subject) || null;
-    const createSubjectMode = String(req.query.create_subject || "").trim() === "1";
-    const initialClassId = (requestedClassId && classes.some((c) => c.id === requestedClassId))
-      ? requestedClassId
-      : (classes.length ? classes[0].id : null);
-    const initialSubjectId = !createSubjectMode && (requestedSubjectId && subjects.some((s) => s.id === requestedSubjectId))
-      ? requestedSubjectId
-      : (subjects.length ? subjects[0].id : null);
+    let prefilledSubjectName = "";
+    if (requestedSubjectId) {
+      const requestedSubject = await assignmentModel.getSubjectById(requestedSubjectId);
+      prefilledSubjectName = String(requestedSubject?.name || "").trim();
+    }
 
-    const assignedTeacherIds = createSubjectMode
-      ? []
-      : assignmentRows
-          .filter(
-            (row) =>
-              Number(row.class_id) === Number(initialClassId) &&
-              Number(row.subject_id) === Number(initialSubjectId)
-          )
-          .map((row) => row.teacher_id);
+    const createSubjectMode =
+      explicitCreateSubjectMode ||
+      Boolean(
+        requestedSubjectId &&
+        prefilledSubjectName &&
+        (!initialClassId ||
+          !classSubjects.some((entry) => Number(entry.subject_id) === requestedSubjectId))
+      );
+
+    const initialSubjectId =
+      !createSubjectMode && requestedSubjectId && classSubjects.some((entry) => Number(entry.subject_id) === requestedSubjectId)
+        ? requestedSubjectId
+        : (!createSubjectMode && classSubjects.length ? Number(classSubjects[0].subject_id) : null);
 
     const flash = consumeFlash(req);
+    const formData = {
+      ...(flash.formData || {})
+    };
+    if (!String(formData.new_subject || "").trim() && prefilledSubjectName) {
+      formData.new_subject = prefilledSubjectName;
+    }
 
     res.render("admin/assignments/new", {
       classes,
-      subjects,
-      teachers: teachersWithNames,
-      assignedTeacherIds,
+      classSubjects,
       selectedClassId: initialClassId,
       selectedSubjectId: initialSubjectId,
       createSubjectMode,
-      formData: flash.formData || null,
+      formData,
+      teacherPageSize: TEACHER_PAGE_SIZE,
+      subjectPrefillId: prefilledSubjectName ? requestedSubjectId : null,
       csrfToken: req.csrfToken(),
       currentUser: req.session.user,
       activePath: req.originalUrl,
@@ -140,20 +217,62 @@ async function renderNewAssignmentForm(req, res, next) {
 
 async function getClassTeachers(req, res, next) {
   try {
-    const classId = Number(req.params.classId);
-    const subjectId = Number(req.query.subject_id) || null;
-    if (!Number.isInteger(classId) || classId <= 0) {
+    const classId = normalizePositiveId(req.params.classId);
+    const rawSubjectId = String(req.query.subject_id || "").trim();
+    const subjectId = rawSubjectId ? normalizePositiveId(rawSubjectId) : null;
+    const query = normalizeSearchQuery(req.query.q);
+    const limit = normalizeLimit(req.query.limit);
+    const offset = normalizeOffset(req.query.offset);
+
+    if (!classId) {
       return res.status(400).json({ error: "Ungültige Klasse." });
     }
-    const rows = await assignmentModel.listAssignmentRows();
-    const teacherIds = rows
-      .filter(
-        (row) =>
-          Number(row.class_id) === classId &&
-          (!subjectId || Number(row.subject_id) === Number(subjectId))
-      )
-      .map((row) => row.teacher_id);
-    return res.json({ teacherIds });
+    if (rawSubjectId && !subjectId) {
+      return res.status(400).json({ error: "Ungültiges Fach." });
+    }
+
+    const classRow = await assignmentModel.getClassById(classId);
+    if (!classRow) {
+      return res.status(404).json({ error: "Klasse nicht gefunden." });
+    }
+
+    if (subjectId) {
+      const subjectRow = await assignmentModel.getSubjectById(subjectId);
+      if (!subjectRow) {
+        return res.status(404).json({ error: "Fach nicht gefunden." });
+      }
+    }
+
+    const assignedTeachers = subjectId
+      ? addDisplayNames(await assignmentModel.listAssignedTeachersForClassSubject(classId, subjectId))
+      : [];
+    const assignedTeacherIds = assignedTeachers.map((entry) => Number(entry.id));
+
+    const [countRow, availableTeacherRows] = await Promise.all([
+      assignmentModel.countTeacherSearchResults({
+        search: query,
+        excludeIds: assignedTeacherIds
+      }),
+      assignmentModel.listTeacherSearchResults({
+        search: query,
+        excludeIds: assignedTeacherIds,
+        limit,
+        offset
+      })
+    ]);
+
+    const availableTeachers = addDisplayNames(availableTeacherRows);
+    const totalAvailable = Number(countRow?.count || 0);
+
+    return res.json({
+      teacherIds: assignedTeacherIds,
+      assignedTeachers,
+      availableTeachers,
+      totalAvailable,
+      limit,
+      offset,
+      hasMore: offset + availableTeachers.length < totalAvailable
+    });
   } catch (err) {
     console.error("DB error loading class teachers:", err);
     next(err);
@@ -255,9 +374,86 @@ async function deleteAssignment(req, res, next) {
   }
 }
 
+async function deleteAssignmentGroup(req, res, next) {
+  try {
+    const classId = normalizePositiveId(req.body?.class_id);
+    const subjectId = normalizePositiveId(req.body?.subject_id);
+
+    if (!subjectId) {
+      return flashAndRedirect(req, res, "/admin/assignments", {
+        error: "Ungültiges Fach."
+      });
+    }
+
+    const subjectRow = await assignmentModel.getSubjectById(subjectId);
+    if (!subjectRow) {
+      return flashAndRedirect(req, res, "/admin/assignments", {
+        error: "Fach nicht gefunden."
+      });
+    }
+
+    if (classId) {
+      const classRow = await assignmentModel.getClassById(classId);
+      if (!classRow) {
+        return flashAndRedirect(req, res, "/admin/assignments", {
+          error: "Klasse nicht gefunden."
+        });
+      }
+
+      const matchingRows = (await assignmentModel.listAssignmentRows()).filter(
+        (row) => Number(row.class_id) === classId && Number(row.subject_id) === subjectId
+      );
+
+      if (!matchingRows.length) {
+        return flashAndRedirect(req, res, "/admin/assignments", {
+          error: "Keine passende Fachgruppe gefunden."
+        });
+      }
+
+      for (const row of matchingRows) {
+        await assignmentModel.deleteAssignment(row.id);
+      }
+
+      return flashAndRedirect(req, res, "/admin/assignments", {
+        message: `Fachgruppe entfernt. ${matchingRows.length} Lehrerzuordnung(en) gelöscht.`
+      });
+    }
+
+    const [assignmentCountRow, exclusionCountRow] = await Promise.all([
+      assignmentModel.countAssignmentsForSubject(subjectId),
+      assignmentModel.countTeacherExclusionsForSubject(subjectId)
+    ]);
+
+    if (Number(assignmentCountRow?.count || 0) > 0 || Number(exclusionCountRow?.count || 0) > 0) {
+      return flashAndRedirect(req, res, "/admin/assignments", {
+        error: "Dieses Fach wird noch verwendet und kann hier nicht gelöscht werden."
+      });
+    }
+
+    try {
+      await assignmentModel.deleteSubject(subjectId);
+    } catch (err) {
+      if (String(err.message || err).includes("FOREIGN KEY")) {
+        return flashAndRedirect(req, res, "/admin/assignments", {
+          error: "Dieses Fach wird noch an anderer Stelle verwendet und kann nicht gelöscht werden."
+        });
+      }
+      throw err;
+    }
+
+    return flashAndRedirect(req, res, "/admin/assignments", {
+      message: "Unzugeordnetes Fach gelöscht."
+    });
+  } catch (err) {
+    console.error("DB error deleting assignment group:", err);
+    next(err);
+  }
+}
+
 module.exports = {
   createAssignment,
   deleteAssignment,
+  deleteAssignmentGroup,
   getClassTeachers,
   renderAssignmentList,
   renderNewAssignmentForm

--- a/school-login/db.js
+++ b/school-login/db.js
@@ -445,6 +445,24 @@ function createFakeDb() {
         for (let i = teachingAssignments.length - 1; i >= 0; i -= 1) {
           if (teachingAssignments[i].id === Number(id)) teachingAssignments.splice(i, 1);
         }
+      } else if (/DELETE FROM subjects WHERE id = \?/i.test(sql)) {
+        const [id] = params;
+        const subjectRefId = Number(id);
+        const isReferenced =
+          classes.some((entry) => entry.subject_id === subjectRefId) ||
+          teachingAssignments.some((entry) => entry.subject_id === subjectRefId) ||
+          gradeTemplates.some((entry) => entry.subject_id === subjectRefId) ||
+          specialAssessments.some((entry) => entry.subject_id === subjectRefId) ||
+          participationMarks.some((entry) => entry.subject_id === subjectRefId) ||
+          teacherStudentExclusions.some((entry) => entry.subject_id === subjectRefId);
+
+        if (isReferenced) {
+          err = new Error("FOREIGN KEY constraint failed");
+        } else {
+          for (let i = subjects.length - 1; i >= 0; i -= 1) {
+            if (subjects[i].id === subjectRefId) subjects.splice(i, 1);
+          }
+        }
       } else if (/INSERT INTO teacher_student_exclusions/i.test(sql)) {
         const [teacher_id, class_id, subject_id, student_id, school_year_id] = params;
         const duplicate = teacherStudentExclusions.find(
@@ -1238,6 +1256,16 @@ function createFakeDb() {
         const [id] = params;
         const subject = subjects.find((entry) => entry.id === Number(id));
         row = subject ? { id: subject.id } : undefined;
+      } else if (/SELECT COUNT\(\*\) AS count FROM class_subject_teacher WHERE subject_id = \?/i.test(sql)) {
+        const [subjectIdParam] = params;
+        row = {
+          count: teachingAssignments.filter((entry) => entry.subject_id === Number(subjectIdParam)).length
+        };
+      } else if (/SELECT COUNT\(\*\) AS count FROM teacher_student_exclusions WHERE subject_id = \?/i.test(sql)) {
+        const [subjectIdParam] = params;
+        row = {
+          count: teacherStudentExclusions.filter((entry) => entry.subject_id === Number(subjectIdParam)).length
+        };
       } else if (/SELECT id, subject_id FROM classes WHERE id = \?/i.test(sql)) {
         const [id] = params;
         const classRow = classes.find((entry) => entry.id === Number(id));
@@ -1340,6 +1368,31 @@ function createFakeDb() {
         const [id] = params;
         const classRow = classes.find((c) => c.id === Number(id));
         row = classRow ? { id: classRow.id } : undefined;
+      } else if (/SELECT COUNT\(\*\) AS count\s+FROM users\s+WHERE role = 'teacher' AND status = 'active'/i.test(sql)) {
+        const hasSearch = /LOWER\(email\) LIKE LOWER\(\?\)/i.test(sql);
+        const hasExclude = /id NOT IN \(/i.test(sql);
+        let paramIndex = 0;
+        let searchNeedle = "";
+
+        if (hasSearch) {
+          searchNeedle = String(params[paramIndex++] || "").toLowerCase().replace(/%/g, "");
+        }
+
+        let excludedIds = [];
+        if (hasExclude) {
+          const placeholderMatch = sql.match(/id NOT IN \(([^)]+)\)/i);
+          const excludeCount = placeholderMatch ? (placeholderMatch[1].match(/\?/g) || []).length : 0;
+          excludedIds = params.slice(paramIndex, paramIndex + excludeCount).map((entry) => Number(entry));
+        }
+
+        row = {
+          count: users.filter((user) => {
+            if (user.role !== "teacher" || user.status !== "active") return false;
+            if (searchNeedle && !String(user.email || "").toLowerCase().includes(searchNeedle)) return false;
+            if (excludedIds.includes(Number(user.id))) return false;
+            return true;
+          }).length
+        };
       } else if (/SELECT COUNT\(\*\) AS count FROM class_subject_teacher WHERE teacher_id = \?/i.test(sql)) {
         const [teacher_id] = params;
         row = {
@@ -1830,6 +1883,34 @@ function createFakeDb() {
           )
           .sort((a, b) => String(a.name || "").localeCompare(String(b.name || "")))
           .map((entry) => ({ name: entry.name }));
+      } else if (/SELECT cst.subject_id,\s*s.name AS subject_name,\s*COUNT\(\*\) AS teacher_count\s+FROM class_subject_teacher cst/i.test(sql) && /WHERE cst.class_id = \? AND sy.is_active = \?/i.test(sql)) {
+        const [classIdParam, isActiveParam] = params;
+        const activeYearIds = schoolYears
+          .filter((entry) => Boolean(entry.is_active) === Boolean(isActiveParam))
+          .map((entry) => Number(entry.id));
+        const subjectMap = new Map();
+
+        teachingAssignments
+          .filter(
+            (entry) =>
+              entry.class_id === Number(classIdParam) &&
+              activeYearIds.includes(Number(entry.school_year_id))
+          )
+          .forEach((entry) => {
+            const subjectRow = subjects.find((subjectEntry) => subjectEntry.id === entry.subject_id) || {};
+            const key = Number(entry.subject_id);
+            if (!subjectMap.has(key)) {
+              subjectMap.set(key, {
+                subject_id: entry.subject_id,
+                subject_name: subjectRow.name || "",
+                teacher_count: 0
+              });
+            }
+            subjectMap.get(key).teacher_count += 1;
+          });
+
+        rows = [...subjectMap.values()]
+          .sort((a, b) => String(a.subject_name || "").localeCompare(String(b.subject_name || "")));
       } else if (/SELECT cst.subject_id,\s*COALESCE\(s.name, c.subject\) AS subject_name\s+FROM class_subject_teacher cst[\s\S]*WHERE cst.class_id = \? AND cst.school_year_id = c.school_year_id/i.test(sql)) {
         const [classIdParam] = params;
         const classRow = classes.find((entry) => entry.id === Number(classIdParam));
@@ -1872,6 +1953,26 @@ function createFakeDb() {
             };
           })
           .sort((a, b) => `${a.subject_name}`.localeCompare(`${b.subject_name}`));
+      } else if (/SELECT u.id,\s*u.email\s+FROM class_subject_teacher cst/i.test(sql) && /WHERE cst.class_id = \? AND cst.subject_id = \? AND sy.is_active = \?/i.test(sql)) {
+        const [classIdParam, subjectIdParam, isActiveParam] = params;
+        const activeYearIds = schoolYears
+          .filter((entry) => Boolean(entry.is_active) === Boolean(isActiveParam))
+          .map((entry) => Number(entry.id));
+        rows = teachingAssignments
+          .filter(
+            (entry) =>
+              entry.class_id === Number(classIdParam) &&
+              entry.subject_id === Number(subjectIdParam) &&
+              activeYearIds.includes(Number(entry.school_year_id))
+          )
+          .map((entry) => {
+            const teacher = users.find((userEntry) => userEntry.id === entry.teacher_id) || {};
+            return {
+              id: entry.teacher_id,
+              email: teacher.email
+            };
+          })
+          .sort((a, b) => String(a.email || "").localeCompare(String(b.email || "")));
       } else if (/SELECT cst.id AS assignment_id, c.id, c.name, s.name AS subject\s+FROM class_subject_teacher cst/i.test(sql)) {
         const [teacherIdParam] = params;
         rows = teachingAssignments
@@ -2054,6 +2155,36 @@ function createFakeDb() {
           .filter((c) => c.teacher_id === Number(teacher_id))
           .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
           .map((c) => ({ id: c.id, name: c.name, subject: c.subject }));
+      } else if (/SELECT id,\s*email\s+FROM users\s+WHERE role = 'teacher' AND status = 'active'[\s\S]*LIMIT \? OFFSET \?/i.test(sql)) {
+        const hasSearch = /LOWER\(email\) LIKE LOWER\(\?\)/i.test(sql);
+        const hasExclude = /id NOT IN \(/i.test(sql);
+        let paramIndex = 0;
+        let searchNeedle = "";
+
+        if (hasSearch) {
+          searchNeedle = String(params[paramIndex++] || "").toLowerCase().replace(/%/g, "");
+        }
+
+        let excludedIds = [];
+        if (hasExclude) {
+          const placeholderMatch = sql.match(/id NOT IN \(([^)]+)\)/i);
+          const excludeCount = placeholderMatch ? (placeholderMatch[1].match(/\?/g) || []).length : 0;
+          excludedIds = params.slice(paramIndex, paramIndex + excludeCount).map((entry) => Number(entry));
+          paramIndex += excludeCount;
+        }
+
+        const limit = Number(params[paramIndex++] || 50);
+        const offset = Number(params[paramIndex] || 0);
+        rows = users
+          .filter((user) => {
+            if (user.role !== "teacher" || user.status !== "active") return false;
+            if (searchNeedle && !String(user.email || "").toLowerCase().includes(searchNeedle)) return false;
+            if (excludedIds.includes(Number(user.id))) return false;
+            return true;
+          })
+          .sort((a, b) => String(a.email || "").localeCompare(String(b.email || "")))
+          .slice(offset, offset + limit)
+          .map((user) => ({ id: user.id, email: user.email }));
       } else if (/SELECT id, email FROM users WHERE role = 'teacher' AND status = 'active'/i.test(sql)) {
         rows = users
           .filter((u) => u.role === "teacher" && u.status === "active")

--- a/school-login/models/assignmentModel.js
+++ b/school-login/models/assignmentModel.js
@@ -22,6 +22,102 @@ async function listTeachers() {
   );
 }
 
+async function countAssignmentsForSubject(subjectId) {
+  if (!Number.isInteger(Number(subjectId)) || Number(subjectId) <= 0) return { count: 0 };
+  return getAsync(
+    "SELECT COUNT(*) AS count FROM class_subject_teacher WHERE subject_id = ?",
+    [subjectId]
+  );
+}
+
+async function countTeacherExclusionsForSubject(subjectId) {
+  if (!Number.isInteger(Number(subjectId)) || Number(subjectId) <= 0) return { count: 0 };
+  return getAsync(
+    "SELECT COUNT(*) AS count FROM teacher_student_exclusions WHERE subject_id = ?",
+    [subjectId]
+  );
+}
+
+async function listClassSubjects(classId) {
+  if (!Number.isInteger(Number(classId)) || Number(classId) <= 0) return [];
+  return allAsync(
+    `SELECT cst.subject_id,
+            s.name AS subject_name,
+            COUNT(*) AS teacher_count
+     FROM class_subject_teacher cst
+     JOIN school_years sy ON sy.id = cst.school_year_id
+     JOIN subjects s ON s.id = cst.subject_id
+     WHERE cst.class_id = ? AND sy.is_active = ?
+     GROUP BY cst.subject_id, s.name
+     ORDER BY s.name ASC`,
+    [classId, true]
+  );
+}
+
+async function listAssignedTeachersForClassSubject(classId, subjectId) {
+  if (!Number.isInteger(Number(classId)) || Number(classId) <= 0) return [];
+  if (!Number.isInteger(Number(subjectId)) || Number(subjectId) <= 0) return [];
+  return allAsync(
+    `SELECT u.id, u.email
+     FROM class_subject_teacher cst
+     JOIN school_years sy ON sy.id = cst.school_year_id
+     JOIN users u ON u.id = cst.teacher_id
+     WHERE cst.class_id = ? AND cst.subject_id = ? AND sy.is_active = ?
+     ORDER BY u.email ASC`,
+    [classId, subjectId, true]
+  );
+}
+
+async function countTeacherSearchResults({ search = "", excludeIds = [] } = {}) {
+  const normalizedSearch = String(search || "").trim();
+  const params = [];
+  const whereParts = ["role = 'teacher'", "status = 'active'"];
+
+  if (normalizedSearch) {
+    whereParts.push("LOWER(email) LIKE LOWER(?)");
+    params.push(`%${normalizedSearch}%`);
+  }
+
+  if (excludeIds.length) {
+    whereParts.push(`id NOT IN (${excludeIds.map(() => "?").join(",")})`);
+    params.push(...excludeIds);
+  }
+
+  return getAsync(
+    `SELECT COUNT(*) AS count
+     FROM users
+     WHERE ${whereParts.join(" AND ")}`,
+    params
+  );
+}
+
+async function listTeacherSearchResults({ search = "", excludeIds = [], limit = 50, offset = 0 } = {}) {
+  const normalizedSearch = String(search || "").trim();
+  const safeLimit = Math.max(Math.min(Number(limit) || 50, 200), 1);
+  const safeOffset = Math.max(Number(offset) || 0, 0);
+  const params = [];
+  const whereParts = ["role = 'teacher'", "status = 'active'"];
+
+  if (normalizedSearch) {
+    whereParts.push("LOWER(email) LIKE LOWER(?)");
+    params.push(`%${normalizedSearch}%`);
+  }
+
+  if (excludeIds.length) {
+    whereParts.push(`id NOT IN (${excludeIds.map(() => "?").join(",")})`);
+    params.push(...excludeIds);
+  }
+
+  return allAsync(
+    `SELECT id, email
+     FROM users
+     WHERE ${whereParts.join(" AND ")}
+     ORDER BY email ASC
+     LIMIT ? OFFSET ?`,
+    [...params, safeLimit, safeOffset]
+  );
+}
+
 async function getClassById(classId) {
   return getAsync("SELECT id, name, subject, subject_id, school_year_id FROM classes WHERE id = ?", [classId]);
 }
@@ -119,16 +215,27 @@ async function deleteAssignment(assignmentId) {
   return runAsync("DELETE FROM class_subject_teacher WHERE id = ?", [assignmentId]);
 }
 
+async function deleteSubject(subjectId) {
+  return runAsync("DELETE FROM subjects WHERE id = ?", [subjectId]);
+}
+
 module.exports = {
+  countAssignmentsForSubject,
+  countTeacherExclusionsForSubject,
   createAssignments,
   deleteAssignment,
+  deleteSubject,
   getClassById,
   getSubjectById,
+  countTeacherSearchResults,
+  listAssignedTeachersForClassSubject,
   listAssignedTeacherIdsForClass,
   listAssignmentGroups,
   listAssignmentRows,
+  listClassSubjects,
   listClasses,
   listSubjects,
+  listTeacherSearchResults,
   listTeachers,
   listValidTeacherIds
 };

--- a/school-login/public/css/admin.css
+++ b/school-login/public/css/admin.css
@@ -1210,6 +1210,62 @@ body.page-admin-edit {
 }
 
 /* ── Assignment form (new page) ── */
+.assign-subject-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.assign-selection-form {
+  align-items: stretch;
+}
+
+.assign-auto-hint {
+  margin-top: 10px;
+}
+
+.assign-row-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.assign-row-delete-form {
+  display: inline-flex;
+  margin: 0;
+}
+
+.assign-btn-remove {
+  min-width: 34px;
+  padding-inline: 0;
+}
+
+.assign-subject-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.assign-subject-chip small {
+  color: var(--text-muted, #6b7280);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.assign-subject-chip.is-active {
+  border-color: rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.08);
+}
+
 .assign-class-info {
   display: flex;
   align-items: center;
@@ -1240,6 +1296,26 @@ body.page-admin-edit {
 
 .assign-teacher-section {
   margin-top: 4px;
+}
+
+.assign-teacher-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.assign-search-row {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.assign-search-row .assign-search-input {
+  flex: 1 1 320px;
+  margin-bottom: 0;
 }
 
 .assign-search-input {
@@ -1388,11 +1464,27 @@ body.page-admin-edit {
   padding: 16px;
 }
 
+.assign-table-empty {
+  color: var(--text-muted, #6b7280);
+  text-align: center;
+}
+
 .assign-selection-count {
   display: inline-flex;
   align-items: center;
   font-size: 13px;
   font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .assign-teacher-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .assign-class-info {
+    flex-wrap: wrap;
+  }
 }
 
 /* ── Assignment index table ── */
@@ -1455,7 +1547,7 @@ body.page-admin-edit {
 }
 
 .assign-col-action {
-  width: 100px;
+  width: 180px;
   text-align: right;
 }
 

--- a/school-login/routes/assignmentRoutes.js
+++ b/school-login/routes/assignmentRoutes.js
@@ -11,5 +11,6 @@ router.get("/assignments/new", assignmentController.renderNewAssignmentForm);
 router.get("/assignments/api/class/:classId/teachers", assignmentController.getClassTeachers);
 router.post("/assignments", assignmentController.createAssignment);
 router.post("/assignments/delete", assignmentController.deleteAssignment);
+router.post("/assignments/delete-group", assignmentController.deleteAssignmentGroup);
 
 module.exports = router;

--- a/school-login/server.test.js
+++ b/school-login/server.test.js
@@ -488,6 +488,141 @@ test("admin archive renders the optimized overview and exports CSV", async () =>
   assert.match(csvResponse.body, /"Kommentar"/);
 });
 
+test("admin assignments page lists subjects without classes or teachers", async () => {
+  const loginResult = await loginAdmin();
+  const subjectName = "Biologie ohne Zuordnung";
+
+  const insertResult = await dbRun("INSERT INTO subjects (name) VALUES (?)", [subjectName]);
+
+  const assignmentsPage = await fetchWithCookies("/admin/assignments", {}, loginResult.cookies);
+  assert.strictEqual(assignmentsPage.response.status, 200);
+  assert.match(assignmentsPage.body, /Fächer verwalten/);
+  assert.match(assignmentsPage.body, new RegExp(subjectName));
+  assert.match(assignmentsPage.body, /Keine Klasse/);
+  assert.match(assignmentsPage.body, /Keine Lehrer zugeordnet\./);
+  await dbRun("DELETE FROM subjects WHERE id = ?", [insertResult.lastID]);
+});
+
+test("admin assignment table can delete an unassigned subject with confirmation flow", async () => {
+  const loginResult = await loginAdmin();
+  const subjectName = "Darstellende Geometrie ohne Zuordnung";
+  const insertResult = await dbRun("INSERT INTO subjects (name) VALUES (?)", [subjectName]);
+  const csrfToken = await fetchCsrfToken("/admin/assignments", loginResult.cookies);
+
+  const deleteResponse = await fetchWithCookies(
+    "/admin/assignments/delete-group",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        _csrf: csrfToken,
+        subject_id: String(insertResult.lastID)
+      }).toString(),
+      redirect: "manual"
+    },
+    loginResult.cookies
+  );
+
+  assert.strictEqual(deleteResponse.response.status, 302);
+  assert.strictEqual(deleteResponse.response.headers.get("location"), "/admin/assignments");
+
+  const refreshedPage = await fetchWithCookies("/admin/assignments", {}, loginResult.cookies);
+  assert.strictEqual(refreshedPage.response.status, 200);
+  assert.match(refreshedPage.body, /Unzugeordnetes Fach gelöscht\./);
+  assert.doesNotMatch(refreshedPage.body, new RegExp(subjectName));
+});
+
+test("admin assignment form only offers subjects from the selected class", async () => {
+  const loginResult = await loginAdmin();
+  const unrelatedSubject = "Deutsch ohne Klassenbezug";
+
+  const insertResult = await dbRun("INSERT INTO subjects (name) VALUES (?)", [unrelatedSubject]);
+
+  const assignmentForm = await fetchWithCookies("/admin/assignments/new?class=1", {}, loginResult.cookies);
+  assert.strictEqual(assignmentForm.response.status, 200);
+  assert.match(assignmentForm.body, /Klassenfach wählen/);
+  assert.match(assignmentForm.body, /Informatik \(1 Lehrer\)/);
+  assert.doesNotMatch(assignmentForm.body, new RegExp(unrelatedSubject));
+  await dbRun("DELETE FROM subjects WHERE id = ?", [insertResult.lastID]);
+});
+
+test("admin assignment teacher api paginates available teachers", async () => {
+  const loginResult = await loginAdmin();
+
+  await dbRun(
+    "INSERT INTO users (email, password_hash, role, status, must_change_password) VALUES (?,?,?,?,?)",
+    ["teacher.one@example.com", "hash", "teacher", "active", 0]
+  );
+  await dbRun(
+    "INSERT INTO users (email, password_hash, role, status, must_change_password) VALUES (?,?,?,?,?)",
+    ["teacher.two@example.com", "hash", "teacher", "active", 0]
+  );
+  await dbRun(
+    "INSERT INTO users (email, password_hash, role, status, must_change_password) VALUES (?,?,?,?,?)",
+    ["teacher.three@example.com", "hash", "teacher", "active", 0]
+  );
+
+  const teacherApiResponse = await fetchWithCookies(
+    "/admin/assignments/api/class/1/teachers?subject_id=1&limit=2",
+    { headers: { Accept: "application/json" } },
+    loginResult.cookies
+  );
+  assert.strictEqual(teacherApiResponse.response.status, 200);
+
+  const teacherApiData = JSON.parse(teacherApiResponse.body);
+  assert.ok(Array.isArray(teacherApiData.assignedTeachers));
+  assert.ok(Array.isArray(teacherApiData.availableTeachers));
+  assert.strictEqual(teacherApiData.assignedTeachers.length, 1);
+  assert.strictEqual(teacherApiData.availableTeachers.length, 2);
+  assert.strictEqual(Number(teacherApiData.totalAvailable), 3);
+  assert.strictEqual(teacherApiData.hasMore, true);
+});
+
+test("admin assignment table can delete a class subject group", async () => {
+  const loginResult = await loginAdmin();
+  const csrfToken = await fetchCsrfToken("/admin/assignments", loginResult.cookies);
+  const activeSchoolYear = await dbGet(
+    "SELECT id, name, start_date, end_date, is_active FROM school_years WHERE is_active = ? ORDER BY id DESC LIMIT 1",
+    [true]
+  );
+  const teacherRow = await dbGet("SELECT id, role FROM users WHERE email = ?", ["teacher@example.com"]);
+
+  try {
+  const deleteResponse = await fetchWithCookies(
+    "/admin/assignments/delete-group",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        _csrf: csrfToken,
+        class_id: "1",
+        subject_id: "1"
+      }).toString(),
+      redirect: "manual"
+    },
+    loginResult.cookies
+  );
+
+  assert.strictEqual(deleteResponse.response.status, 302);
+  assert.strictEqual(deleteResponse.response.headers.get("location"), "/admin/assignments");
+
+  const assignmentsPage = await fetchWithCookies("/admin/assignments", {}, loginResult.cookies);
+  assert.strictEqual(assignmentsPage.response.status, 200);
+  assert.match(assignmentsPage.body, /Fachgruppe entfernt\. 1 Lehrerzuordnung\(en\) gelöscht\./);
+  assert.doesNotMatch(assignmentsPage.body, /teacher@example\.com/);
+  assert.match(assignmentsPage.body, /Noch keine Zuordnungen vorhanden\./);
+
+  const assignmentForm = await fetchWithCookies("/admin/assignments/new?class=1", {}, loginResult.cookies);
+  assert.strictEqual(assignmentForm.response.status, 200);
+  assert.match(assignmentForm.body, /Diese Klasse hat noch keine Fächer\./);
+  } finally {
+    await dbRun(
+      "INSERT INTO class_subject_teacher (class_id, subject_id, teacher_id, school_year_id) VALUES (?,?,?,?)",
+      [1, 1, teacherRow.id, activeSchoolYear.id]
+    );
+  }
+});
+
 test("audit logs keep appended changes and return live updates in descending order", async () => {
   const loginResult = await loginAdmin();
 

--- a/school-login/views/admin/assignments/index.ejs
+++ b/school-login/views/admin/assignments/index.ejs
@@ -16,8 +16,9 @@
           <div>
             <p class="app-main-subtitle">Unterrichtszuordnungen</p>
             <h1>Lehrer nach Klasse und Fach</h1>
-            <p class="admin-muted">Hier siehst du alle Lehrer-Klasse-Zuordnungen im aktuellen Schuljahr.</p>
+            <p class="admin-muted">Hier siehst du alle Lehrer-Klasse-Zuordnungen im aktuellen Schuljahr sowie Fächer ohne bestehende Zuordnung.</p>
           </div>
+          <a class="btn btn-secondary" href="/admin/assignments/new">Fächer verwalten</a>
         </div>
 
         <% if (message) { %>
@@ -31,7 +32,7 @@
           <div class="admin-topbar">
             <div>
               <p class="admin-eyebrow">Übersicht</p>
-              <h3>Aktive Zuordnungen</h3>
+              <h3>Zuordnungen und offene Fächer</h3>
             </div>
             <span class="admin-badge"><%= assignments.length %> Gruppen</span>
           </div>
@@ -61,35 +62,71 @@
                 </thead>
                 <tbody>
                   <% assignments.forEach((assignmentGroup) => { %>
+                    <%
+                      const deleteTitle = assignmentGroup.class_id ? 'Fachgruppe löschen' : 'Fach löschen';
+                      const deleteMessage = assignmentGroup.class_id
+                        ? `Möchtest du ${assignmentGroup.subject_name} aus ${assignmentGroup.class_name} wirklich löschen?`
+                        : `Möchtest du das unzugeordnete Fach ${assignmentGroup.subject_name} wirklich löschen?`;
+                      const deleteNote = assignmentGroup.class_id
+                        ? 'Alle Lehrerzuordnungen dieser Fachgruppe im aktiven Schuljahr werden entfernt. Gelöschte Daten sind möglicherweise nicht wiederherstellbar.'
+                        : 'Das Fach wird vollständig gelöscht, wenn es nirgends mehr verwendet wird. Gelöschte Daten sind möglicherweise nicht wiederherstellbar.';
+                    %>
                     <tr data-search="<%= assignmentGroup.class_name.toLowerCase() %> <%= assignmentGroup.subject_name.toLowerCase() %> <%= assignmentGroup.rows.map((r) => (r.teacher_display_name + ' ' + r.teacher_email).toLowerCase()).join(' ') %>">
                       <td class="assign-col-class">
                         <span class="assign-class-badge"><%= assignmentGroup.class_name %></span>
                       </td>
                       <td class="assign-col-subject"><%= assignmentGroup.subject_name %></td>
                       <td class="assign-col-teachers">
-                        <div class="assign-chips">
-                          <% assignmentGroup.rows.forEach((row) => { %>
-                            <span class="assign-chip">
-                              <span class="assign-chip-name"><%= row.teacher_display_name %></span>
-                              <form
-                                method="POST"
-                                action="/admin/assignments/delete"
-                                class="assign-chip-form"
-                                data-confirm-title="Zuordnung entfernen"
-                                data-confirm-message="<%= row.teacher_display_name %> (<%= row.teacher_email %>) von <%= assignmentGroup.class_name %> – <%= assignmentGroup.subject_name %> entfernen?"
-                                data-confirm-action="Entfernen"
-                                data-confirm-variant="danger"
-                              >
-                                <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                                <input type="hidden" name="assignment_id" value="<%= row.id %>">
-                                <button class="assign-chip-remove" type="submit" title="<%= row.teacher_display_name %> entfernen">&times;</button>
-                              </form>
-                            </span>
-                          <% }) %>
-                        </div>
+                        <% if (assignmentGroup.rows.length) { %>
+                          <div class="assign-chips">
+                            <% assignmentGroup.rows.forEach((row) => { %>
+                              <span class="assign-chip">
+                                <span class="assign-chip-name"><%= row.teacher_display_name %></span>
+                                <form
+                                  method="POST"
+                                  action="/admin/assignments/delete"
+                                  class="assign-chip-form"
+                                  data-confirm-title="Zuordnung entfernen"
+                                  data-confirm-message="<%= row.teacher_display_name %> (<%= row.teacher_email %>) von <%= assignmentGroup.class_name %> – <%= assignmentGroup.subject_name %> entfernen?"
+                                  data-confirm-action="Entfernen"
+                                  data-confirm-variant="danger"
+                                >
+                                  <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                                  <input type="hidden" name="assignment_id" value="<%= row.id %>">
+                                  <button class="assign-chip-remove" type="submit" title="<%= row.teacher_display_name %> entfernen">&times;</button>
+                                </form>
+                              </span>
+                            <% }) %>
+                          </div>
+                        <% } else { %>
+                          <span class="admin-muted">Keine Lehrer zugeordnet.</span>
+                        <% } %>
                       </td>
                       <td class="assign-col-action">
-                        <a class="btn btn-secondary btn-sm assign-btn-add" href="/admin/assignments/new?class=<%= assignmentGroup.class_id %>&subject=<%= assignmentGroup.subject_id %>">+ Lehrer</a>
+                        <div class="assign-row-actions">
+                          <% if (assignmentGroup.class_id) { %>
+                            <a class="btn btn-secondary btn-sm assign-btn-add" href="/admin/assignments/new?class=<%= assignmentGroup.class_id %>&subject=<%= assignmentGroup.subject_id %>">+ Lehrer</a>
+                          <% } else { %>
+                            <a class="btn btn-secondary btn-sm assign-btn-add" href="/admin/assignments/new?subject=<%= assignmentGroup.subject_id %>">Klasse wählen</a>
+                          <% } %>
+                          <form
+                            method="POST"
+                            action="/admin/assignments/delete-group"
+                            class="assign-row-delete-form"
+                            data-confirm-title="<%= deleteTitle %>"
+                            data-confirm-message="<%= deleteMessage %>"
+                            data-confirm-note="<%= deleteNote %>"
+                            data-confirm-action="Löschen"
+                            data-confirm-variant="danger"
+                          >
+                            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                            <% if (assignmentGroup.class_id) { %>
+                              <input type="hidden" name="class_id" value="<%= assignmentGroup.class_id %>">
+                            <% } %>
+                            <input type="hidden" name="subject_id" value="<%= assignmentGroup.subject_id %>">
+                            <button class="btn btn-danger btn-sm assign-btn-remove" type="submit" title="<%= deleteTitle %>">X</button>
+                          </form>
+                        </div>
                       </td>
                     </tr>
                   <% }) %>

--- a/school-login/views/admin/assignments/new.ejs
+++ b/school-login/views/admin/assignments/new.ejs
@@ -1,11 +1,16 @@
 <%
-  const selClassId = selectedClassId ? String(selectedClassId) : (classes.length ? String(classes[0].id) : '');
-  const selSubjectId = selectedSubjectId ? String(selectedSubjectId) : (subjects.length ? String(subjects[0].id) : '');
+  const selClassId = selectedClassId ? String(selectedClassId) : '';
+  const selSubjectId = selectedSubjectId ? String(selectedSubjectId) : '';
   const selectedClass = classes.find((entry) => String(entry.id) === selClassId) || null;
-  const selectedSubject = subjects.find((entry) => String(entry.id) === selSubjectId) || null;
-  const assignedSet = new Set(assignedTeacherIds.map(Number));
+  const selectedSubject = classSubjects.find((entry) => String(entry.subject_id) === selSubjectId) || null;
   const newSubjectName = formData && formData.new_subject ? String(formData.new_subject) : '';
   const canAssign = Boolean(selectedClass && (createSubjectMode || selectedSubject));
+  const existingModeHref = selClassId
+    ? `/admin/assignments/new?class=${encodeURIComponent(selClassId)}`
+    : '/admin/assignments/new';
+  const createModeHref =
+    `/admin/assignments/new?${selClassId ? `class=${encodeURIComponent(selClassId)}&` : ''}create_subject=1` +
+    `${subjectPrefillId ? `&subject=${encodeURIComponent(subjectPrefillId)}` : ''}`;
   const page = {
     title: 'Admin - Lehrer zuordnen',
     headerTitle: 'Adminbereich',
@@ -23,7 +28,7 @@
           <div>
             <p class="app-main-subtitle">Unterrichtszuordnungen</p>
             <h1>Lehrer einem Klassenfach zuordnen</h1>
-            <p class="admin-muted">Klassen können ohne Fach starten. Hier wird das Fach pro Zuordnung festgelegt.</p>
+            <p class="admin-muted">Wähle zuerst eine Klasse. Danach arbeitest du nur mit den Fächern dieser Klasse oder legst ein neues Fach direkt für diese Klasse an.</p>
           </div>
           <a class="btn btn-secondary" href="/admin/assignments">Zur Übersicht</a>
         </div>
@@ -36,43 +41,90 @@
         <% } %>
 
         <div class="admin-card">
-          <% if (createSubjectMode) { %>
-            <form class="admin-form" method="GET" action="/admin/assignments/new">
-              <select name="class">
-                <% (classes || []).forEach((entry) => { %>
-                  <option value="<%= entry.id %>" <%= selClassId === String(entry.id) ? 'selected' : '' %>><%= entry.name %></option>
-                <% }) %>
-              </select>
+          <div class="admin-create-shell assign-mode-shell" data-active-mode="<%= createSubjectMode ? 'bulk' : 'single' %>">
+            <div class="admin-mode-switch" role="tablist" aria-label="Zuordnungsmodus">
+              <span class="admin-mode-switch-indicator" aria-hidden="true"></span>
+              <button
+                type="button"
+                class="admin-mode-switch-option <%= createSubjectMode ? '' : 'is-active' %>"
+                data-assign-mode-href="<%= existingModeHref %>"
+                role="tab"
+                aria-selected="<%= createSubjectMode ? 'false' : 'true' %>"
+              >
+                Bestehendes Klassenfach
+              </button>
+              <button
+                type="button"
+                class="admin-mode-switch-option <%= createSubjectMode ? 'is-active' : '' %>"
+                data-assign-mode-href="<%= createModeHref %>"
+                role="tab"
+                aria-selected="<%= createSubjectMode ? 'true' : 'false' %>"
+              >
+                Neues Fach für Klasse
+              </button>
+            </div>
+
+            <form class="admin-form assign-selection-form" id="assignment-selection-form" method="GET" action="/admin/assignments/new">
+            <select name="class" required>
+              <option value="">Klasse wählen</option>
+              <% (classes || []).forEach((entry) => { %>
+                <option value="<%= entry.id %>" <%= selClassId === String(entry.id) ? 'selected' : '' %>><%= entry.name %></option>
+              <% }) %>
+            </select>
+
+            <% if (createSubjectMode) { %>
               <input type="hidden" name="create_subject" value="1">
-              <button class="btn btn-secondary" type="submit">Klasse laden</button>
-              <a class="btn" href="/admin/assignments/new?class=<%= encodeURIComponent(selClassId) %>">Bestehendes Fach wählen</a>
-            </form>
-          <% } else { %>
-            <form class="admin-form" method="GET" action="/admin/assignments/new">
-              <select name="class">
-                <% (classes || []).forEach((entry) => { %>
-                  <option value="<%= entry.id %>" <%= selClassId === String(entry.id) ? 'selected' : '' %>><%= entry.name %></option>
+              <% if (subjectPrefillId) { %>
+                <input type="hidden" name="subject" value="<%= subjectPrefillId %>">
+              <% } %>
+            <% } else { %>
+              <select name="subject" <%= !selectedClass || !classSubjects.length ? 'disabled' : '' %>>
+                <option value="">Klassenfach wählen</option>
+                <% (classSubjects || []).forEach((entry) => { %>
+                  <option value="<%= entry.subject_id %>" <%= selSubjectId === String(entry.subject_id) ? 'selected' : '' %>>
+                    <%= entry.subject_name %> (<%= entry.teacher_count %> Lehrer)
+                  </option>
                 <% }) %>
               </select>
-              <select name="subject">
-                <% (subjects || []).forEach((entry) => { %>
-                  <option value="<%= entry.id %>" <%= selSubjectId === String(entry.id) ? 'selected' : '' %>><%= entry.name %></option>
-                <% }) %>
-              </select>
+            <% } %>
+
+            <noscript>
               <button class="btn btn-secondary" type="submit">Ansicht laden</button>
-              <a class="btn" href="/admin/assignments/new?class=<%= encodeURIComponent(selClassId) %>&create_subject=1">Neues Fach anlegen</a>
+            </noscript>
             </form>
-          <% } %>
+          </div>
+
           <% if (!classes.length) { %>
             <p class="admin-muted">Es gibt noch keine Klassen im aktiven Schuljahr.</p>
-          <% } else if (!subjects.length) { %>
-            <p class="admin-muted">Es gibt noch keine Fächer. Lege unten ein neues Fach an und ordne es direkt Lehrern zu.</p>
+          <% } else if (!selectedClass) { %>
+            <p class="admin-muted">Wähle zuerst eine Klasse. Erst danach werden passende Klassenfächer und Lehrkräfte geladen.</p>
+          <% } else if (!createSubjectMode && !classSubjects.length) { %>
+            <p class="admin-muted">Diese Klasse hat noch keine Fächer. Wechsle oben auf <strong>Neues Fach für Klasse</strong>, um das erste Fach anzulegen.</p>
+          <% } %>
+
+          <% if (selectedClass && classSubjects.length) { %>
+            <div class="assign-subject-summary">
+              <% classSubjects.forEach((entry) => { %>
+                <span class="assign-subject-chip <%= !createSubjectMode && selSubjectId === String(entry.subject_id) ? 'is-active' : '' %>">
+                  <span><%= entry.subject_name %></span>
+                  <small><%= entry.teacher_count %> Lehrer</small>
+                </span>
+              <% }) %>
+            </div>
           <% } %>
         </div>
 
         <% if (canAssign) { %>
           <div class="admin-card">
-            <form class="admin-form vertical" id="assignment-form" method="POST" action="/admin/assignments">
+            <form
+              class="admin-form vertical"
+              id="assignment-form"
+              method="POST"
+              action="/admin/assignments"
+              data-page-size="<%= teacherPageSize %>"
+              data-teacher-api="/admin/assignments/api/class/<%= selectedClass.id %>/teachers"
+              data-subject-id="<%= createSubjectMode ? '' : selSubjectId %>"
+            >
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <input type="hidden" name="class_id" value="<%= selClassId %>">
               <input type="hidden" name="create_subject" value="<%= createSubjectMode ? '1' : '0' %>">
@@ -80,9 +132,9 @@
               <div class="assign-class-info">
                 <span class="assign-class-info-label">Klasse:</span>
                 <span class="assign-class-info-value"><%= selectedClass.name %></span>
-                <span class="assign-class-info-sep">&mdash;</span>
+                <span class="assign-class-info-sep">-</span>
                 <span class="assign-class-info-label">Fach:</span>
-                <span class="assign-class-info-value"><%= createSubjectMode ? 'Neues Fach' : selectedSubject.name %></span>
+                <span class="assign-class-info-value" id="assignment-subject-preview"><%= createSubjectMode ? (newSubjectName || 'Neues Fach für diese Klasse') : selectedSubject.subject_name %></span>
               </div>
 
               <% if (createSubjectMode) { %>
@@ -95,65 +147,78 @@
                   placeholder="z.B. Mathematik"
                   required
                 >
-                <p class="admin-muted">Dieses Fach wird angelegt und direkt der gewählten Klasse mit den markierten Lehrern zugeordnet.</p>
+                <p class="admin-muted">Das Fach wird im Kontext dieser Klasse angelegt. Besteht der Fachname bereits, wird der vorhandene Fachdatensatz verwendet und nur die Lehrerzuordnung ergänzt.</p>
               <% } else { %>
                 <input type="hidden" name="subject_id" value="<%= selSubjectId %>">
+                <p class="admin-muted">Hier ordnest du Lehrkräfte nur einem bereits vorhandenen Klassenfach zu.</p>
               <% } %>
 
               <div class="assign-teacher-section">
-                <label>Lehrer auswählen</label>
-                <input
-                  type="text"
-                  id="teacher-search"
-                  class="assign-search-input"
-                  placeholder="Lehrer suchen..."
-                  autocomplete="off"
-                >
+                <div class="assign-teacher-toolbar">
+                  <div>
+                    <label for="teacher-search">Lehrer auswählen</label>
+                  </div>
+                  <span class="admin-muted assign-selection-count" id="selection-count"></span>
+                </div>
 
-                <div id="assigned-section" class="assign-group" style="<%= assignedSet.size ? '' : 'display:none' %>">
-                  <p class="assign-group-title">Bereits zugeordnet (<span id="assigned-count"><%= assignedSet.size %></span>)</p>
+                <div class="assign-search-row">
+                  <input
+                    type="text"
+                    id="teacher-search"
+                    class="assign-search-input"
+                    placeholder="Lehrer nach E-Mail suchen..."
+                    autocomplete="off"
+                  >
+                  <button class="btn btn-secondary" type="button" id="teacher-search-reset">Zurücksetzen</button>
+                  <button class="btn btn-secondary" type="button" id="teacher-load-more" hidden>Mehr laden</button>
+                </div>
+
+                <p class="admin-muted" id="teacher-summary">Lehrer werden geladen...</p>
+
+                <div id="assigned-section" class="assign-group" hidden>
+                  <p class="assign-group-title">Bereits zugeordnet</p>
                   <div class="assign-new-table-wrap">
                     <table class="assign-new-table" id="assigned-list">
-                      <thead><tr><th>Name</th><th>E-Mail</th><th>Status</th></tr></thead>
-                      <tbody>
-                        <% teachers.filter((t) => assignedSet.has(t.id)).forEach((teacher) => { %>
-                          <tr data-teacher-id="<%= teacher.id %>" data-search="<%= teacher.display_name.toLowerCase() %> <%= teacher.email.toLowerCase() %>" class="is-assigned">
-                            <td><%= teacher.display_name %></td>
-                            <td class="assign-email-cell"><%= teacher.email %></td>
-                            <td><span class="assign-badge-assigned">Zugeordnet</span></td>
-                          </tr>
-                        <% }) %>
-                      </tbody>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>E-Mail</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody></tbody>
                     </table>
                   </div>
                 </div>
 
                 <div id="available-section" class="assign-group">
-                  <p class="assign-group-title">Verfügbare Lehrer (<span id="available-count"><%= teachers.filter((t) => !assignedSet.has(t.id)).length %></span>)</p>
+                  <p class="assign-group-title">Verfügbare Lehrer</p>
                   <div class="assign-new-table-wrap">
                     <table class="assign-new-table" id="available-list">
-                      <thead><tr><th class="assign-col-check"></th><th>Name</th><th>E-Mail</th></tr></thead>
-                      <tbody>
-                        <% teachers.filter((t) => !assignedSet.has(t.id)).forEach((teacher) => { %>
-                          <tr data-teacher-id="<%= teacher.id %>" data-search="<%= teacher.display_name.toLowerCase() %> <%= teacher.email.toLowerCase() %>">
-                            <td><label class="assign-check-cell"><input type="checkbox" class="assign-card-checkbox" name="teacher_ids" value="<%= teacher.id %>"></label></td>
-                            <td><%= teacher.display_name %></td>
-                            <td class="assign-email-cell"><%= teacher.email %></td>
-                          </tr>
-                        <% }) %>
-                      </tbody>
+                      <thead>
+                        <tr>
+                          <th class="assign-col-check"></th>
+                          <th>Name</th>
+                          <th>E-Mail</th>
+                        </tr>
+                      </thead>
+                      <tbody></tbody>
                     </table>
                   </div>
                 </div>
 
-                <p class="admin-muted assign-no-results" id="no-results" style="display:none">Keine Lehrer gefunden.</p>
+                <p class="admin-muted assign-no-results" id="no-results" hidden>Keine Lehrer gefunden.</p>
+                <div id="selected-inputs"></div>
               </div>
 
               <div class="admin-row wrap" style="margin-top: 8px">
                 <button class="btn btn-primary" type="submit" id="submit-btn">Lehrer zuordnen</button>
-                <span class="admin-muted assign-selection-count" id="selection-count"></span>
               </div>
             </form>
+
+            <noscript>
+              <p class="admin-muted">Für die Lehrersuche auf dieser Seite ist JavaScript erforderlich.</p>
+            </noscript>
           </div>
         <% } %>
       </section>
@@ -161,48 +226,272 @@
 
     <script>
       (function () {
-        var searchInput = document.getElementById('teacher-search');
-        var assignedSection = document.getElementById('assigned-section');
-        var availableSection = document.getElementById('available-section');
-        var noResults = document.getElementById('no-results');
-        var selectionCount = document.getElementById('selection-count');
-        var assignmentForm = document.getElementById('assignment-form');
-
-        if (!searchInput || !assignedSection || !availableSection || !selectionCount || !assignmentForm) return;
-
-        function filterTeachers() {
-          var query = searchInput.value.trim().toLowerCase();
-          var assignedRows = assignedSection.querySelectorAll('tbody tr[data-search]');
-          var availableRows = availableSection.querySelectorAll('tbody tr[data-search]');
-          var visibleAssigned = 0;
-          var visibleAvailable = 0;
-
-          assignedRows.forEach(function(row) {
-            var match = !query || (row.getAttribute('data-search') || '').indexOf(query) !== -1;
-            row.style.display = match ? 'table-row' : 'none';
-            if (match) visibleAssigned++;
+        Array.prototype.forEach.call(document.querySelectorAll('[data-assign-mode-href]'), function (button) {
+          button.addEventListener('click', function () {
+            var targetUrl = button.getAttribute('data-assign-mode-href');
+            if (!targetUrl) return;
+            window.location.href = targetUrl;
           });
-
-          availableRows.forEach(function(row) {
-            var match = !query || (row.getAttribute('data-search') || '').indexOf(query) !== -1;
-            row.style.display = match ? 'table-row' : 'none';
-            if (match) visibleAvailable++;
-          });
-
-          assignedSection.style.display = (assignedRows.length && visibleAssigned > 0) ? '' : 'none';
-          availableSection.style.display = visibleAvailable > 0 ? '' : 'none';
-          if (noResults) noResults.style.display = (visibleAvailable + visibleAssigned === 0) ? '' : 'none';
-        }
-
-        function updateSelectionCount() {
-          var checked = document.querySelectorAll('#available-list input[type="checkbox"]:checked');
-          selectionCount.textContent = checked.length ? checked.length + ' Lehrer ausgewählt' : '';
-        }
-
-        searchInput.addEventListener('input', filterTeachers);
-        assignmentForm.addEventListener('change', function(e) {
-          if (e.target.type === 'checkbox') updateSelectionCount();
         });
+
+        var selectionForm = document.getElementById('assignment-selection-form');
+        if (selectionForm) {
+          Array.prototype.forEach.call(selectionForm.querySelectorAll('select[name]'), function (select) {
+            select.addEventListener('change', function () {
+              if (select.disabled) return;
+              if (selectionForm.requestSubmit) {
+                selectionForm.requestSubmit();
+                return;
+              }
+              selectionForm.submit();
+            });
+          });
+        }
+
+        var newSubjectInput = document.getElementById('new_subject');
+        var subjectPreview = document.getElementById('assignment-subject-preview');
+        if (newSubjectInput && subjectPreview) {
+          var syncSubjectPreview = function () {
+            var value = newSubjectInput.value.trim();
+            subjectPreview.textContent = value || 'Neues Fach für diese Klasse';
+          };
+
+          newSubjectInput.addEventListener('input', syncSubjectPreview);
+          syncSubjectPreview();
+        }
+
+        var assignmentForm = document.getElementById('assignment-form');
+        if (!assignmentForm) return;
+
+        var apiUrl = assignmentForm.getAttribute('data-teacher-api');
+        var subjectId = assignmentForm.getAttribute('data-subject-id');
+        var pageSize = Number(assignmentForm.getAttribute('data-page-size') || 50);
+        var searchInput = document.getElementById('teacher-search');
+        var resetButton = document.getElementById('teacher-search-reset');
+        var loadMoreButton = document.getElementById('teacher-load-more');
+        var summary = document.getElementById('teacher-summary');
+        var noResults = document.getElementById('no-results');
+        var assignedSection = document.getElementById('assigned-section');
+        var assignedBody = document.querySelector('#assigned-list tbody');
+        var availableBody = document.querySelector('#available-list tbody');
+        var selectedInputs = document.getElementById('selected-inputs');
+        var selectionCount = document.getElementById('selection-count');
+
+        var state = {
+          query: '',
+          offset: 0,
+          totalAvailable: 0,
+          hasMore: false,
+          availableTeachers: [],
+          selectedTeachers: new Map(),
+          activeRequestId: 0
+        };
+        var searchTimer = null;
+
+        function syncSelectedInputs() {
+          selectedInputs.innerHTML = '';
+          state.selectedTeachers.forEach(function (teacher) {
+            var input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'teacher_ids';
+            input.value = String(teacher.id);
+            selectedInputs.appendChild(input);
+          });
+        }
+
+        function updateSelectionCount(messageOverride) {
+          if (messageOverride) {
+            selectionCount.textContent = messageOverride;
+            return;
+          }
+          selectionCount.textContent = state.selectedTeachers.size
+            ? state.selectedTeachers.size + ' Lehrer ausgewählt'
+            : '';
+        }
+
+        function appendEmptyRow(tbody, colspan, message) {
+          var row = document.createElement('tr');
+          var cell = document.createElement('td');
+          cell.colSpan = colspan;
+          cell.className = 'assign-table-empty';
+          cell.textContent = message;
+          row.appendChild(cell);
+          tbody.appendChild(row);
+        }
+
+        function renderAssigned(teachers) {
+          assignedBody.innerHTML = '';
+          if (!teachers.length) {
+            assignedSection.hidden = true;
+            return;
+          }
+
+          assignedSection.hidden = false;
+          teachers.forEach(function (teacher) {
+            var row = document.createElement('tr');
+            row.className = 'is-assigned';
+
+            var nameCell = document.createElement('td');
+            nameCell.textContent = teacher.display_name;
+            row.appendChild(nameCell);
+
+            var emailCell = document.createElement('td');
+            emailCell.className = 'assign-email-cell';
+            emailCell.textContent = teacher.email;
+            row.appendChild(emailCell);
+
+            var statusCell = document.createElement('td');
+            var badge = document.createElement('span');
+            badge.className = 'assign-badge-assigned';
+            badge.textContent = 'Zugeordnet';
+            statusCell.appendChild(badge);
+            row.appendChild(statusCell);
+
+            assignedBody.appendChild(row);
+          });
+        }
+
+        function renderAvailable() {
+          availableBody.innerHTML = '';
+
+          if (!state.availableTeachers.length) {
+            appendEmptyRow(availableBody, 3, 'Keine verfügbaren Lehrer für die aktuelle Auswahl.');
+          } else {
+            state.availableTeachers.forEach(function (teacher) {
+              var row = document.createElement('tr');
+              row.setAttribute('data-teacher-id', String(teacher.id));
+
+              var checkCell = document.createElement('td');
+              checkCell.className = 'assign-col-check';
+              var checkLabel = document.createElement('label');
+              checkLabel.className = 'assign-check-cell';
+              var checkbox = document.createElement('input');
+              checkbox.type = 'checkbox';
+              checkbox.className = 'assign-card-checkbox';
+              checkbox.checked = state.selectedTeachers.has(Number(teacher.id));
+              checkbox.addEventListener('change', function () {
+                if (checkbox.checked) {
+                  state.selectedTeachers.set(Number(teacher.id), teacher);
+                } else {
+                  state.selectedTeachers.delete(Number(teacher.id));
+                }
+                syncSelectedInputs();
+                updateSelectionCount();
+              });
+              checkLabel.appendChild(checkbox);
+              checkCell.appendChild(checkLabel);
+              row.appendChild(checkCell);
+
+              var nameCell = document.createElement('td');
+              nameCell.textContent = teacher.display_name;
+              row.appendChild(nameCell);
+
+              var emailCell = document.createElement('td');
+              emailCell.className = 'assign-email-cell';
+              emailCell.textContent = teacher.email;
+              row.appendChild(emailCell);
+
+              availableBody.appendChild(row);
+            });
+          }
+
+          loadMoreButton.hidden = !state.hasMore;
+          noResults.hidden = !(state.totalAvailable === 0 && state.query);
+        }
+
+        function updateSummary() {
+          if (state.totalAvailable === 0) {
+            summary.textContent = state.query
+              ? 'Keine Treffer für die aktuelle Suche.'
+              : 'Keine verfügbaren Lehrer gefunden.';
+            return;
+          }
+
+          summary.textContent = state.query
+            ? state.availableTeachers.length + ' von ' + state.totalAvailable + ' Treffern geladen.'
+            : state.availableTeachers.length + ' von ' + state.totalAvailable + ' verfügbaren Lehrern geladen.';
+        }
+
+        function loadTeachers(reset) {
+          if (!apiUrl) return;
+          if (reset) {
+            state.offset = 0;
+            state.availableTeachers = [];
+          }
+
+          summary.textContent = 'Lehrer werden geladen...';
+          loadMoreButton.disabled = true;
+          resetButton.disabled = true;
+
+          var params = new URLSearchParams();
+          if (subjectId) params.set('subject_id', subjectId);
+          if (state.query) params.set('q', state.query);
+          params.set('limit', String(pageSize));
+          params.set('offset', String(state.offset));
+
+          var requestId = ++state.activeRequestId;
+          fetch(apiUrl + '?' + params.toString(), {
+            headers: { Accept: 'application/json' }
+          })
+            .then(function (response) {
+              if (!response.ok) throw new Error('Lehrerliste konnte nicht geladen werden.');
+              return response.json();
+            })
+            .then(function (data) {
+              if (requestId !== state.activeRequestId) return;
+
+              renderAssigned(Array.isArray(data.assignedTeachers) ? data.assignedTeachers : []);
+              var nextTeachers = Array.isArray(data.availableTeachers) ? data.availableTeachers : [];
+              state.availableTeachers = reset ? nextTeachers : state.availableTeachers.concat(nextTeachers);
+              state.totalAvailable = Number(data.totalAvailable || 0);
+              state.hasMore = Boolean(data.hasMore);
+              state.offset += nextTeachers.length;
+
+              renderAvailable();
+              updateSummary();
+              syncSelectedInputs();
+              updateSelectionCount();
+            })
+            .catch(function () {
+              summary.textContent = 'Lehrerliste konnte nicht geladen werden.';
+              availableBody.innerHTML = '';
+              appendEmptyRow(availableBody, 3, 'Beim Laden der Lehrer ist ein Fehler aufgetreten.');
+              loadMoreButton.hidden = true;
+              noResults.hidden = true;
+            })
+            .finally(function () {
+              loadMoreButton.disabled = false;
+              resetButton.disabled = false;
+            });
+        }
+
+        searchInput.addEventListener('input', function () {
+          window.clearTimeout(searchTimer);
+          searchTimer = window.setTimeout(function () {
+            state.query = String(searchInput.value || '').trim();
+            loadTeachers(true);
+          }, 250);
+        });
+
+        resetButton.addEventListener('click', function () {
+          state.query = '';
+          searchInput.value = '';
+          loadTeachers(true);
+          searchInput.focus();
+        });
+
+        loadMoreButton.addEventListener('click', function () {
+          if (!state.hasMore) return;
+          loadTeachers(false);
+        });
+
+        assignmentForm.addEventListener('submit', function (event) {
+          if (state.selectedTeachers.size > 0) return;
+          event.preventDefault();
+          updateSelectionCount('Mindestens einen Lehrer wählen.');
+        });
+
+        loadTeachers(true);
       })();
     </script>
 <% } }; %>


### PR DESCRIPTION
Changelog
•Added unassigned subjects to /admin/assignments, including subjects with no teachers and no classes.
•Adjusted the assignments overview so truly unassigned subjects are shown with fallback labels like No class / No teachers assigned.
•Excluded subjects from the “unassigned” list when they are already linked to a class, even if no teacher is assigned yet.
•Added a Manage Subjects button on /admin/assignments that links to /admin/assignments/new.
•Added an X delete button to each row in /admin/assignments.
•Connected the row delete action to the existing confirmation modal with a stronger destructive warning.
•Implemented safe group deletion:
•Deleting a class-subject row removes all teacher assignments for that class-subject group in the active school year.
•Deleting an unassigned subject removes the subject record only if it is not referenced anywhere else.
•Reworked /admin/assignments/new into a class-first workflow instead of a global subject-assignment screen.
•Limited the “existing subject” dropdown to subjects that actually belong to the selected class.
•Prevented arbitrary class-subject combinations from being created through the old UI flow.
•Added a two-mode switch for Existing class subject vs New subject for class.
•Updated that mode switch to use the same slider style as /admin/users/new.
•Enabled auto-loading when a class or subject is selected from the dropdowns.
•Kept the old manual reload button only as a noscript fallback.
•Switched teacher loading on /admin/assignments/new to server-side search with pagination so large datasets load efficiently.
•Added live preview behavior so the subject summary updates while typing a new subject name.
•Removed the helper texts about server-side teacher loading and automatic reloads.
•Added targeted tests for:
•listing subjects without assignments,
•class-scoped subject selection,
•paginated teacher loading,
•deleting an unassigned subject,
•deleting a class-subject group.