### PR TITLE
fixxed small error

### DIFF
--- a/school-login/db.js
+++ b/school-login/db.js
@@ -2265,7 +2265,7 @@ function createFakeDb() {
             student_id: entry.student_id,
             excluded_at: entry.excluded_at
           }));
-      } else if (/SELECT\s+id,\s*name,\s*email\s+FROM students\s+WHERE class_id = \?/i.test(sql) && /ORDER BY name/i.test(sql)) {
+      } else if (/SELECT\s+(DISTINCT\s+)?id,\s*name,\s*email\s+FROM students\s+WHERE class_id = \?/i.test(sql) && /ORDER BY name/i.test(sql)) {
         const hasNameFilter = /LOWER\(name\) LIKE LOWER\(\?\)/i.test(sql);
         const hasEmailFilter = /LOWER\(email\) LIKE LOWER\(\?\)/i.test(sql);
         let index = 0;

--- a/school-login/routes/teacher.js
+++ b/school-login/routes/teacher.js
@@ -890,6 +890,26 @@ async function loadClassSubjectsForTeacher(classId, teacherId) {
   );
 }
 
+function getRequestedSubjectSelection(req, classId) {
+  const rememberedSubjectId =
+    req.session?.teacherSubjectSelections?.[String(classId)] ?? null;
+  const subjectIdRaw =
+    req.params?.subjectId ??
+    req.query?.subject_id ??
+    req.body?.subject_id ??
+    rememberedSubjectId;
+  const hasSubjectConstraint = subjectIdRaw != null && String(subjectIdRaw).trim() !== "";
+  if (!hasSubjectConstraint) {
+    return { hasSubjectConstraint: false, requestedSubjectId: null, isValid: true };
+  }
+  const requestedSubjectId = Number(subjectIdRaw);
+  return {
+    hasSubjectConstraint: true,
+    requestedSubjectId,
+    isValid: Number.isFinite(requestedSubjectId)
+  };
+}
+
 async function loadClassForTeacher(classId, teacherId, requestedSubjectId = null) {
   const classRow = await getAsync(
     "SELECT id, name, subject, subject_id, school_year_id, created_at FROM classes WHERE id = ?",
@@ -928,6 +948,14 @@ async function loadClassForTeacher(classId, teacherId, requestedSubjectId = null
   };
 }
 
+function rememberTeacherSubjectSelection(req, classId, subjectId) {
+  if (!Number.isFinite(Number(subjectId))) return;
+  req.session.teacherSubjectSelections = {
+    ...(req.session.teacherSubjectSelections || {}),
+    [String(classId)]: Number(subjectId)
+  };
+}
+
 async function requireClassAccessForTeacher(req, res, classId, backUrl = "/teacher/classes") {
   const classExists = await getAsync("SELECT id FROM classes WHERE id = ?", [classId]);
   if (!classExists) {
@@ -935,16 +963,8 @@ async function requireClassAccessForTeacher(req, res, classId, backUrl = "/teach
     return null;
   }
 
-  const rememberedSubjectId =
-    req.session?.teacherSubjectSelections?.[String(classId)] ?? null;
-  const subjectIdRaw =
-    req.params?.subjectId ??
-    req.query?.subject_id ??
-    req.body?.subject_id ??
-    rememberedSubjectId;
-  const hasSubjectConstraint = subjectIdRaw != null && String(subjectIdRaw).trim() !== "";
-  const requestedSubjectId = hasSubjectConstraint ? Number(subjectIdRaw) : null;
-  if (hasSubjectConstraint && !Number.isFinite(requestedSubjectId)) {
+  const { hasSubjectConstraint, requestedSubjectId, isValid } = getRequestedSubjectSelection(req, classId);
+  if (hasSubjectConstraint && !isValid) {
     renderError(res, req, "Ungültiges Fach.", 400, backUrl);
     return null;
   }
@@ -966,10 +986,7 @@ async function requireClassAccessForTeacher(req, res, classId, backUrl = "/teach
     renderError(res, req, "Keine Berechtigung für diese Klasse/Fach-Zuordnung.", 403, backUrl);
     return null;
   }
-  req.session.teacherSubjectSelections = {
-    ...(req.session.teacherSubjectSelections || {}),
-    [String(classId)]: classData.subject_id
-  };
+  rememberTeacherSubjectSelection(req, classId, classData.subject_id);
   return classData;
 }
 
@@ -1039,6 +1056,69 @@ async function loadTemplateForClass(classId, subjectId, templateId) {
     [templateId, classId, subjectId]
   );
   return template ? enrichWeightData(template) : null;
+}
+
+async function loadTemplateForTeacher(classId, teacherId, templateId, requestedSubjectId = null) {
+  const subjectRows = await loadClassSubjectsForTeacher(classId, teacherId);
+  const accessibleSubjectIds = [...new Set(
+    subjectRows
+      .map((row) => Number(row.subject_id))
+      .filter((subjectId) => Number.isFinite(subjectId))
+  )];
+  if (!accessibleSubjectIds.length) return null;
+
+  let allowedSubjectIds = accessibleSubjectIds;
+  if (requestedSubjectId != null) {
+    const normalizedSubjectId = Number(requestedSubjectId);
+    if (!accessibleSubjectIds.includes(normalizedSubjectId)) return null;
+    allowedSubjectIds = [normalizedSubjectId];
+  }
+
+  const templates = await allAsync(
+    `SELECT id, name, category, weight, weight_mode, max_points, date, description, subject_id
+     FROM grade_templates
+     WHERE class_id = ?
+     ORDER BY date, name`,
+    [classId]
+  );
+  const template = (templates || []).find(
+    (entry) =>
+      Number(entry.id) === Number(templateId) &&
+      allowedSubjectIds.includes(Number(entry.subject_id))
+  );
+  return template ? enrichWeightData(template) : null;
+}
+
+async function loadTemplateContextForTeacher(req, res, classId, templateId, backUrl = `/teacher/grade-templates/${classId}`) {
+  const subjectSelection = getRequestedSubjectSelection(req, classId);
+  const classData = await requireClassAccessForTeacher(req, res, classId, backUrl);
+  if (!classData) return null;
+
+  const template = await loadTemplateForTeacher(
+    classId,
+    req.session.user.id,
+    templateId,
+    subjectSelection.hasSubjectConstraint ? subjectSelection.requestedSubjectId : null
+  );
+  if (!template) {
+    renderError(res, req, "Prüfung nicht gefunden.", 404, backUrl);
+    return null;
+  }
+  if (Number(template.subject_id) === Number(classData.subject_id)) {
+    return { classData, template };
+  }
+
+  const matchingClassData = await loadClassForTeacher(
+    classId,
+    req.session.user.id,
+    template.subject_id
+  );
+  if (!matchingClassData) {
+    renderError(res, req, "Keine Berechtigung für diese Klasse/Fach-Zuordnung.", 403, "/teacher/classes");
+    return null;
+  }
+  rememberTeacherSubjectSelection(req, classId, matchingClassData.subject_id);
+  return { classData: matchingClassData, template };
 }
 
 async function loadExistingGradesForTemplate(classId, subjectId, templateId) {
@@ -3647,15 +3727,9 @@ router.get("/bulk-grade-template/:classId/:templateId", async (req, res, next) =
   try {
     const classId = req.params.classId;
     const templateId = req.params.templateId;
-    const classData = await loadClassForTeacher(classId, req.session.user.id);
-    if (!classData) {
-      return renderError(res, req, "Klasse nicht gefunden.", 404, "/teacher/classes");
-    }
-
-    const template = await loadTemplateForClass(classId, classData.subject_id, templateId);
-    if (!template) {
-      return renderError(res, req, "Prüfung nicht gefunden.", 404, `/teacher/grade-templates/${classId}`);
-    }
+    const templateContext = await loadTemplateContextForTeacher(req, res, classId, templateId);
+    if (!templateContext) return;
+    const { classData, template } = templateContext;
 
     const activeProfile = await loadActiveTeacherProfile(req.session.user.id);
     if (!activeProfile) {
@@ -3712,15 +3786,9 @@ router.post("/bulk-grade-template/:classId/:templateId", async (req, res, next) 
   try {
     const classId = req.params.classId;
     const templateId = req.params.templateId;
-    const classData = await loadClassForTeacher(classId, req.session.user.id);
-    if (!classData) {
-      return renderError(res, req, "Klasse nicht gefunden.", 404, "/teacher/classes");
-    }
-
-    const template = await loadTemplateForClass(classId, classData.subject_id, templateId);
-    if (!template) {
-      return renderError(res, req, "Prüfung nicht gefunden.", 404, `/teacher/grade-templates/${classId}`);
-    }
+    const templateContext = await loadTemplateContextForTeacher(req, res, classId, templateId);
+    if (!templateContext) return;
+    const { classData, template } = templateContext;
 
     const activeProfile = await loadActiveTeacherProfile(req.session.user.id);
     if (!activeProfile) {

--- a/school-login/server.test.js
+++ b/school-login/server.test.js
@@ -468,6 +468,52 @@ test("teacher bulk grading saves entries for numeric student ids", async () => {
   assert.doesNotMatch(resultPage.body, /Keine neuen Bewertungen zum Speichern gefunden\./);
 });
 
+test("teacher bulk grading resolves templates for the correct subject on multi-subject classes", async () => {
+  const loginResult = await loginTeacher();
+  assert.strictEqual(loginResult.redirect, "/teacher");
+
+  const teacherRow = await dbGet("SELECT id FROM users WHERE email = ?", ["teacher@example.com"]);
+  assert.ok(teacherRow?.id, "Teacher user missing");
+
+  const activeProfile = await dbGet(
+    "SELECT id FROM teacher_grading_profiles WHERE teacher_id = ? AND is_active = ? ORDER BY id ASC LIMIT 1",
+    [teacherRow.id, 1]
+  );
+  if (!activeProfile) {
+    await dbRun(
+      `INSERT INTO teacher_grading_profiles
+       (teacher_id, name, weight_mode, scoring_mode, absence_mode, grade1_min_percent, grade2_min_percent, grade3_min_percent, grade4_min_percent, ma_enabled, ma_weight, ma_grade_plus, ma_grade_plus_tilde, ma_grade_neutral, ma_grade_minus_tilde, ma_grade_minus, is_active)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [teacherRow.id, "Bulkprofil Mehrfachfach", "points", "points_or_grade", "include_zero", 88.5, 75, 62.5, 50, 0, 5, 1.5, 2.5, 3, 3.5, 4.5, 1]
+    );
+  }
+
+  const activeSchoolYear = await dbGet(
+    "SELECT id, name, start_date, end_date, is_active FROM school_years WHERE is_active = ? ORDER BY id DESC LIMIT 1",
+    [1]
+  );
+  assert.ok(activeSchoolYear?.id, "Active school year missing");
+
+  const subjectInsert = await dbRun("INSERT INTO subjects (name) VALUES (?)", ["Mehrfachfach Mathematik"]);
+  await dbRun(
+    "INSERT INTO class_subject_teacher (class_id, subject_id, teacher_id, school_year_id) VALUES (?,?,?,?)",
+    [1, subjectInsert.lastID, teacherRow.id, activeSchoolYear.id]
+  );
+  const templateInsert = await dbRun(
+    "INSERT INTO grade_templates (class_id, subject_id, name, category, weight, weight_mode, max_points, date, description) VALUES (?,?,?,?,?,?,?,?,?)",
+    [1, subjectInsert.lastID, "Mehrfachfach-Test", "Test", 1, "points", 20, "2026-04-20", "Regression fuer Bulk-Benotung"]
+  );
+
+  const bulkPage = await fetchWithCookies(
+    `/teacher/bulk-grade-template/1/${templateInsert.lastID}`,
+    {},
+    loginResult.cookies
+  );
+  assert.strictEqual(bulkPage.response.status, 200);
+  assert.match(bulkPage.body, /Mehrfachfach-Test/);
+  assert.match(bulkPage.body, /Mehrfachfach Mathematik/);
+});
+
 test("student routes redirect when unauthenticated", async () => {
   const res = await fetchWithCookies("/student/grades", { redirect: "manual" });
   assert.strictEqual(res.response.status, 302);


### PR DESCRIPTION
•Fixed 404 "Exam not found" on /teacher/bulk-grade-template/:classId/:templateId.
•Updated bulk grading to resolve templates against the teacher’s actual class-subject assignments instead of relying on the class’s default/first subject.
•Synced the remembered teacher subject selection with the template’s real subject_id when opening bulk grading.
•Reused the same template-resolution logic for both bulk grading GET and POST routes.
•Added a regression test for multi-subject classes to ensure bulk grading opens the correct exam template.
•Updated the fake DB test matcher so bulk grading student queries with SELECT DISTINCT continue to work in tests.