### PR TITLE
Superhotfix

### DIFF
--- a/school-login/routes/teacher.js
+++ b/school-login/routes/teacher.js
@@ -1416,6 +1416,10 @@ function shouldSkipGradeForAbsence(grade, absenceMode) {
   return normalizeAbsenceMode(absenceMode) === ABSENCE_MODE_EXCLUDE;
 }
 
+function isGradeExcludedFromAverage(grade, absenceMode) {
+  return Boolean(grade?.excluded_from_average) || shouldSkipGradeForAbsence(grade, absenceMode);
+}
+
 function isValidGradeValue(value) {
   const numeric = Number(value);
   return Number.isFinite(numeric) && numeric >= 1 && numeric <= 5;
@@ -1441,8 +1445,7 @@ function computeWeightedAverage(grades, options = {}) {
   let weightTotal = 0;
 
   grades.forEach((grade) => {
-    if (grade?.excluded_from_average) return;
-    if (shouldSkipGradeForAbsence(grade, absenceMode)) return;
+    if (isGradeExcludedFromAverage(grade, absenceMode)) return;
     const value = Number(grade?.grade);
     const weight = grade?.weight == null ? 1 : Number(grade.weight);
     if (!isValidGradeValue(value) || !isValidWeightValue(weight)) return;
@@ -1486,8 +1489,7 @@ function computePointTotalsWithParticipation(entries, options = {}) {
   const absenceMode = normalizeAbsenceMode(options.absenceMode);
   return (entries || []).reduce(
     (acc, row) => {
-      if (row?.excluded_from_average) return acc;
-      if (shouldSkipGradeForAbsence(row, absenceMode)) return acc;
+      if (isGradeExcludedFromAverage(row, absenceMode)) return acc;
 
       const achieved = Number(row?.points_achieved);
       const max = Number(row?.points_max);
@@ -2744,6 +2746,9 @@ router.get("/student-grades/:classId/:studentId", async (req, res, next) => {
     const grades = gradeRows.map((row) => {
       const hasAttachment = Boolean(row.attachment_path);
       const resolvedWeightMode = row.is_special ? fallbackMode : resolveWeightMode(row.weight_mode);
+      const excludedFromAverage = Boolean(row.excluded_from_average);
+      const excludedByAbsenceProfile = shouldSkipGradeForAbsence(row, absenceMode);
+      const neutralizedForAverage = isGradeExcludedFromAverage(row, absenceMode);
       const pointsAchieved = Number(row.points_achieved);
       const pointsMax = Number(row.points_max);
       const hasPoints = Number.isFinite(pointsAchieved) && Number.isFinite(pointsMax) && pointsMax > 0;
@@ -2760,11 +2765,12 @@ router.get("/student-grades/:classId/:studentId", async (req, res, next) => {
         points_percent: pointsPercent,
         note: row.note,
         is_absent: Boolean(row.is_absent),
-        excluded_from_average: Boolean(row.excluded_from_average),
+        excluded_from_average: excludedFromAverage,
+        excluded_by_absence_profile: excludedByAbsenceProfile,
         category: row.category,
         weight: row.weight,
         weight_mode: resolvedWeightMode,
-        weight_label: row.excluded_from_average
+        weight_label: neutralizedForAverage
           ? "Ohne Gewichtung"
           : formatWeightLabel(row.weight, resolvedWeightMode),
         template_name: row.name,
@@ -2823,8 +2829,7 @@ router.get("/student-grades/:classId/:studentId", async (req, res, next) => {
             source: "participation"
           }))
         ]
-          .filter((row) => !row.excluded_from_average)
-          .filter((row) => !shouldSkipGradeForAbsence(row, absenceMode))
+          .filter((row) => !isGradeExcludedFromAverage(row, absenceMode))
           .filter(
             (row) =>
               isValidGradeValue(row.grade) &&
@@ -2915,12 +2920,12 @@ router.get("/student-grades/:classId/:studentId/details", async (req, res, next)
       const excludedFromAverage = Boolean(row.excluded_from_average);
       const isAbsent = Boolean(row.is_absent);
       const skippedForAbsence = shouldSkipGradeForAbsence({ is_absent: isAbsent }, absenceMode);
+      const neutralizedForAverage = excludedFromAverage || skippedForAbsence;
       const hasValidGrade = isValidGradeValue(gradeValue);
       const hasValidWeight = isValidWeightValue(effectiveWeight);
       const included =
         !studentExcluded &&
-        !excludedFromAverage &&
-        !skippedForAbsence &&
+        !neutralizedForAverage &&
         hasValidGrade &&
         hasValidWeight;
       const contributionValue = included ? gradeValue * effectiveWeight : 0;
@@ -2957,7 +2962,7 @@ router.get("/student-grades/:classId/:studentId/details", async (req, res, next)
         include_reason: includeReason,
         grade: hasValidGrade ? Number(gradeValue.toFixed(2)) : null,
         raw_weight: isValidWeightValue(rawWeight) ? Number(rawWeight.toFixed(2)) : null,
-        effective_weight: excludedFromAverage
+        effective_weight: neutralizedForAverage
           ? 0
           : hasValidWeight
             ? Number(effectiveWeight.toFixed(2))
@@ -4645,7 +4650,7 @@ router.get("/class-statistics/:classId", async (req, res, next) => {
         const student = studentMap.get(studentId);
         grades.forEach((grade) => {
           if (grade.is_special) return;
-          if (shouldSkipGradeForAbsence(grade, absenceMode)) return;
+          if (isGradeExcludedFromAverage(grade, absenceMode)) return;
           const matchesById =
             grade.template_id && Number(grade.template_id) === Number(template.id);
           const matchesByName = !grade.template_id && grade.name === template.name;
@@ -4696,7 +4701,7 @@ router.get("/class-statistics/:classId", async (req, res, next) => {
 
     gradesByStudent.forEach((grades) => {
       grades.forEach((grade) => {
-        if (shouldSkipGradeForAbsence(grade, absenceMode)) return;
+        if (isGradeExcludedFromAverage(grade, absenceMode)) return;
         const value = Number(grade.grade);
         const weight = grade?.weight == null ? 1 : Number(grade.weight);
         if (!isValidGradeValue(value) || !isValidWeightValue(weight)) return;

--- a/school-login/server.test.js
+++ b/school-login/server.test.js
@@ -514,6 +514,81 @@ test("teacher bulk grading resolves templates for the correct subject on multi-s
   assert.match(bulkPage.body, /Mehrfachfach Mathematik/);
 });
 
+test('teacher student grades treat "nicht da" with absence_mode=exclude as ohne Gewichtung', async () => {
+  const loginResult = await loginTeacher();
+  assert.strictEqual(loginResult.redirect, "/teacher");
+
+  const teacherRow = await dbGet("SELECT id FROM users WHERE email = ?", ["teacher@example.com"]);
+  assert.ok(teacherRow?.id, "Teacher user missing");
+
+  const classRow = await dbGet("SELECT id, subject_id FROM classes WHERE id = ?", [1]);
+  assert.ok(classRow?.subject_id, "Class subject missing");
+
+  const activeSchoolYear = await dbGet(
+    "SELECT id, name, start_date, end_date, is_active FROM school_years WHERE is_active = ? ORDER BY id DESC LIMIT 1",
+    [1]
+  );
+  assert.ok(activeSchoolYear?.id, "Active school year missing");
+
+  await dbRun("UPDATE teacher_grading_profiles SET is_active = ? WHERE teacher_id = ?", [
+    0,
+    teacherRow.id
+  ]);
+  await dbRun(
+    `INSERT INTO teacher_grading_profiles
+     (teacher_id, name, weight_mode, scoring_mode, absence_mode, grade1_min_percent, grade2_min_percent, grade3_min_percent, grade4_min_percent, ma_enabled, ma_weight, ma_grade_plus, ma_grade_plus_tilde, ma_grade_neutral, ma_grade_minus_tilde, ma_grade_minus, is_active)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      teacherRow.id,
+      `Abwesenheit Neutral ${Date.now()}`,
+      "points",
+      "points_or_grade",
+      "exclude",
+      88.5,
+      75,
+      62.5,
+      50,
+      0,
+      5,
+      1.5,
+      2.5,
+      3,
+      3.5,
+      4.5,
+      1
+    ]
+  );
+
+  const templateInsert = await dbRun(
+    "INSERT INTO grade_templates (class_id, subject_id, name, category, weight, weight_mode, max_points, date, description) VALUES (?,?,?,?,?,?,?,?,?)",
+    [
+      1,
+      classRow.subject_id,
+      `Abwesenheitstest ${Date.now()}`,
+      "Test",
+      10,
+      "points",
+      20,
+      "2026-04-20",
+      "Regression fuer nicht da"
+    ]
+  );
+
+  await dbRun(
+    "INSERT INTO grades (student_id, class_id, grade_template_id, grade, points_achieved, points_max, note, attachment_path, attachment_original_name, attachment_mime, attachment_size, external_link, is_absent, school_year_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+    [1, 1, templateInsert.lastID, 5, null, null, "War nicht da", null, null, null, null, null, 1, activeSchoolYear.id]
+  );
+
+  const studentGradesPage = await fetchWithCookies("/teacher/student-grades/1/1", {}, loginResult.cookies);
+  assert.strictEqual(studentGradesPage.response.status, 200);
+  assert.match(studentGradesPage.body, /Ohne Gewichtung/);
+  assert.match(studentGradesPage.body, /Nicht gewichtet laut Einstellung bei &quot;nicht da&quot;|Nicht gewichtet laut Einstellung bei "nicht da"/);
+
+  const detailsPage = await fetchWithCookies("/teacher/student-grades/1/1/details", {}, loginResult.cookies);
+  assert.strictEqual(detailsPage.response.status, 200);
+  assert.match(detailsPage.body, /Nicht gewichtet \(Abwesenheit laut Profil\)\./);
+});
+
 test("student routes redirect when unauthenticated", async () => {
   const res = await fetchWithCookies("/student/grades", { redirect: "manual" });
   assert.strictEqual(res.response.status, 302);

--- a/school-login/views/login.ejs
+++ b/school-login/views/login.ejs
@@ -63,7 +63,7 @@
         <div class="login-foot">
           <div class="login-foot-item">
             <span class="login-foot-icon">👥</span>
-            <span>Sitz, Grasberger, Granzer, Aslani, Reisinger</span>
+            <span>Sitz, Grasberger, Granzer, Aslani</span>
           </div>
         </div>
       </div>

--- a/school-login/views/teacher/teacher-student-grades.ejs
+++ b/school-login/views/teacher/teacher-student-grades.ejs
@@ -269,6 +269,8 @@
                   <% } %>
                   <% if (grade.excluded_from_average) { %>
                     <p class="teacher-muted">Gewichtung entfernt. Der Eintrag bleibt sichtbar, zählt aber nicht zur Gesamtnote.</p>
+                  <% } else if (grade.excluded_by_absence_profile) { %>
+                    <p class="teacher-muted">Nicht gewichtet laut Einstellung bei "nicht da".</p>
                   <% } %>
                   <% if (grade.note) { %>
                     <p class="grade-description"><%= grade.note %></p>


### PR DESCRIPTION
•Fixed /teacher/settings so Bei "nicht da" -> Nicht gewichten now behaves like Remove weighting in the teacher grade view.
•Unified grade exclusion logic so absence-based neutral entries are treated as unweighted in averages, grade details, wish-grade calculations, and class statistics.
•Added a regression test for absence_mode=exclude to verify absent grades are shown and handled as Ohne Gewichtung.
•Removed Reisinger from the staff list shown on the /login page.