### PR TITLE
Pw reset

### DIFF
--- a/school-login/public/css/admin.css
+++ b/school-login/public/css/admin.css
@@ -690,25 +690,134 @@ body.page-admin-edit {
   gap: 10px;
 }
 
-.admin-user-edit-reset-mail {
+.admin-user-edit-password-status {
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.admin-user-edit-password-status strong {
+  font-size: 1.05em;
+}
+
+.admin-user-edit-reset-options {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 14px;
-  align-items: start;
+  gap: 12px;
+}
+
+.admin-user-edit-reset-option {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  align-items: stretch;
   padding: 14px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: rgba(14, 165, 233, 0.06);
 }
 
-.admin-user-edit-reset-mail h4,
+.admin-user-edit-reset-option h4,
 .admin-user-edit-reset-history h4 {
   margin: 0 0 6px;
+}
+
+.admin-user-edit-reset-option form {
+  min-width: 0;
+  width: 100%;
+}
+
+.admin-user-edit-reset-option .admin-stacked-form {
+  min-width: 0;
+}
+
+.admin-user-edit-reset-option > form:not(.admin-stacked-form) {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.admin-user-edit-reset-option .admin-field {
+  min-width: 0;
+}
+
+.admin-user-edit-reset-option .admin-user-edit-actions {
+  justify-content: flex-end;
+}
+
+.admin-user-edit-reset-option .btn {
+  white-space: nowrap;
+}
+
+@media (min-width: 1120px) {
+  .admin-user-edit-reset-option:not(.is-custom) {
+    grid-template-columns: minmax(0, 1fr) max-content;
+    align-items: center;
+  }
+
+  .admin-user-edit-reset-option:not(.is-custom) > form {
+    width: auto;
+  }
+
+  .admin-user-edit-reset-option.is-custom .admin-stacked-form {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) max-content;
+    align-items: end;
+    gap: 12px;
+  }
+
+  .admin-user-edit-reset-option.is-custom .admin-user-edit-actions {
+    align-self: end;
+  }
 }
 
 .admin-user-edit-reset-history {
   display: grid;
   gap: 10px;
+}
+
+.admin-user-edit-reset-history summary {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 9px 13px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.admin-user-edit-reset-history summary::-webkit-details-marker {
+  display: none;
+}
+
+.admin-user-edit-reset-history summary::after {
+  content: "anzeigen";
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.admin-user-edit-reset-history[open] summary::after {
+  content: "ausblenden";
+}
+
+.admin-user-edit-reset-count {
+  min-width: 26px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.12);
+  color: var(--accent);
+  font-size: 0.78rem;
+  line-height: 1;
+  text-align: center;
+}
+
+.admin-user-edit-reset-history-body {
+  margin-top: 10px;
 }
 
 .admin-user-edit-reset-history ul {
@@ -954,7 +1063,7 @@ body.page-admin-edit {
     position: static;
   }
 
-  .admin-user-edit-reset-mail {
+  .admin-user-edit-reset-option {
     grid-template-columns: 1fr;
   }
 
@@ -964,7 +1073,7 @@ body.page-admin-edit {
   }
 
   .admin-user-edit-actions .btn,
-  .admin-user-edit-reset-mail .btn,
+  .admin-user-edit-reset-option .btn,
   .admin-user-edit-ms-form .btn {
     width: 100%;
   }

--- a/school-login/public/css/login.css
+++ b/school-login/public/css/login.css
@@ -467,6 +467,135 @@ body.page-force-password {
   display: block;
 }
 
+.changepw-shell {
+  width: min(100%, 460px);
+  display: grid;
+  place-items: center;
+}
+
+.changepw-card {
+  width: 100%;
+  display: grid;
+  gap: 20px;
+  padding: 30px;
+  border-radius: 12px;
+  border: 1px solid #dbeafe;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.14);
+}
+
+.changepw-brand {
+  margin-bottom: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.changepw-brand .login-mark {
+  width: 120px;
+}
+
+.changepw-header {
+  display: grid;
+  gap: 8px;
+  text-align: center;
+}
+
+.changepw-header h1 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+.changepw-header p {
+  margin: 0;
+  color: #64748b;
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.changepw-form {
+  display: grid;
+  gap: 12px;
+}
+
+.changepw-form label {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  color: #111827;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.changepw-form label small {
+  min-width: 0;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.changepw-form input[type="password"] {
+  width: 100%;
+  min-height: 46px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  color: #0f172a;
+  font-size: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.changepw-form input[type="password"]:focus {
+  outline: none;
+  border-color: #003da5;
+  background: #ffffff;
+  box-shadow: 0 0 0 3px rgba(0, 61, 165, 0.12);
+}
+
+.changepw-error {
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid #fecdd3;
+  background: #fff1f2;
+  color: #9f1239;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.changepw-note {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 8px;
+  background: #eff6ff;
+  color: #1e3a8a;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.changepw-note p {
+  margin: 0;
+}
+
+.changepw-note-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  background: #003da5;
+  color: #ffffff;
+  font-weight: 800;
+}
+
 @media (max-width: 900px), (orientation: portrait) and (max-height: 980px) {
   body.page-login,
   body.page-force-password {
@@ -572,6 +701,29 @@ body.page-force-password {
     padding: 5px 7px;
     font-size: 9px;
     line-height: 1.3;
+  }
+
+  .changepw-shell {
+    width: min(100%, 420px);
+  }
+
+  .changepw-card {
+    max-height: calc(100dvh - clamp(16px, 4dvh, 40px));
+    overflow: auto;
+    padding: clamp(18px, 4dvh, 26px) clamp(16px, 5vw, 24px);
+  }
+
+  .changepw-header h1 {
+    font-size: clamp(23px, 7vw, 28px);
+  }
+
+  .changepw-form label {
+    display: grid;
+    gap: 4px;
+  }
+
+  .changepw-form label small {
+    text-align: left;
   }
 }
 

--- a/school-login/routes/admin.js
+++ b/school-login/routes/admin.js
@@ -965,6 +965,12 @@ function resolveUserEditFeedback(query = {}) {
   if (query.passwordReset === "sent") {
     return { tone: "success", message: "Einmalpasswort wurde per E-Mail versendet." };
   }
+  if (query.passwordReset === "custom") {
+    return { tone: "success", message: "Passwort wurde durch den Admin gesetzt." };
+  }
+  if (query.passwordReset === "initial") {
+    return { tone: "success", message: "Initial-Kennwort wurde gesetzt. Der Nutzer muss beim naechsten Login ein eigenes Passwort vergeben." };
+  }
   return null;
 }
 
@@ -1688,7 +1694,11 @@ router.post("/users/:id/reset", async (req, res, next) => {
   const id = req.params.id;
   const { password, useInitial } = req.body || {};
   const wantsInitial = useInitial === "1";
-  const backUrl = wantsInitial ? "/admin/users" : `/admin/users/${id}/edit`;
+  const editUrl = `/admin/users/${id}/edit`;
+  const returnTo = typeof req.body?.returnTo === "string" && req.body.returnTo.startsWith("/admin/users/")
+    ? req.body.returnTo
+    : null;
+  const backUrl = returnTo || (wantsInitial ? "/admin/users" : editUrl);
 
   if (!wantsInitial && !password) {
     return res.status(400).render("error", {
@@ -1737,6 +1747,10 @@ router.post("/users/:id/reset", async (req, res, next) => {
   try {
     await runAsync("UPDATE users SET password_hash = ?, must_change_password = ? WHERE id = ?", [hash, mustChange, id]);
     await passwordResetModel.invalidateActiveRequestsForUser(id);
+    if (returnTo) {
+      const feedback = wantsInitial ? "initial" : "custom";
+      return res.redirect(`${returnTo}?passwordReset=${feedback}`);
+    }
     res.redirect("/admin/users");
   } catch (err) {
     console.error("DB error resetting password:", err);

--- a/school-login/server.js
+++ b/school-login/server.js
@@ -97,6 +97,7 @@ function isDbConnectionError(err) {
 const LOGIN_RATE_WINDOW_MS = Number(process.env.LOGIN_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 const LOGIN_RATE_MAX = Number(process.env.LOGIN_RATE_LIMIT_MAX) || 5;
 const MAINTENANCE_LOGIN_TOKEN_TTL_MS = 10 * 60 * 1000;
+const PASSWORD_CHANGE_PATH = "/changepw";
 const loginAttempts = new Map();
 const teamsEmbedEnabled = parseOptionalBoolean(process.env.TEAMS_EMBED_ENABLED) ?? false;
 const teamsMicrosoftLoginOnly =
@@ -428,7 +429,7 @@ function createUserSession(req, user, loginKey) {
         if (saveErr) return reject(saveErr);
         resolve(
           shouldRequirePasswordChange(user)
-            ? "/force-password-change"
+            ? PASSWORD_CHANGE_PATH
             : getRedirectForRole(user.role)
         );
       });
@@ -657,10 +658,10 @@ function createSessionForUser(req, user, next) {
 app.use((req, res, next) => {
   const user = req.session.user;
   if (!user || !user.must_change_password) return next();
-  if (req.path === "/force-password-change" || req.path === "/logout") {
+  if (req.path === PASSWORD_CHANGE_PATH || req.path === "/force-password-change" || req.path === "/logout") {
     return next();
   }
-  return res.redirect("/force-password-change");
+  return res.redirect(PASSWORD_CHANGE_PATH);
 });
 
 app.use(async (req, res, next) => {
@@ -916,30 +917,23 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
   }
 });
 
-// --- Passwortwechsel erzwingen ---
-app.get("/force-password-change", requireAuth, (req, res) => {
-  if (!req.session.user.must_change_password) {
-    return res.redirect(getRedirectForRole(req.session.user.role));
-  }
-  res.render("force-password-change", {
+function renderPasswordChangePage(req, res, options = {}) {
+  return res.render("force-password-change", {
     email: req.session.user.email,
     csrfToken: req.csrfToken(),
-    error: null
+    error: options.error || null
   });
-});
+}
 
-app.post("/force-password-change", requireAuth, async (req, res, next) => {
+async function handleForcedPasswordChange(req, res, next) {
   if (!req.session.user.must_change_password) {
     return res.redirect(getRedirectForRole(req.session.user.role));
   }
   const newPassword = req.body?.newPassword;
   const validationError = getPasswordValidationError(newPassword);
   if (validationError) {
-    return res.status(400).render("force-password-change", {
-      email: req.session.user.email,
-      csrfToken: req.csrfToken(),
-      error: validationError
-    });
+    res.status(400);
+    return renderPasswordChangePage(req, res, { error: validationError });
   }
   const hash = hashPassword(newPassword);
   try {
@@ -953,7 +947,19 @@ app.post("/force-password-change", requireAuth, async (req, res, next) => {
   } catch (err) {
     return next(err);
   }
+}
+
+// --- Passwortwechsel erzwingen ---
+app.get(PASSWORD_CHANGE_PATH, requireAuth, (req, res) => {
+  if (!req.session.user.must_change_password) {
+    return res.redirect(getRedirectForRole(req.session.user.role));
+  }
+  return renderPasswordChangePage(req, res);
 });
+
+app.post(PASSWORD_CHANGE_PATH, requireAuth, handleForcedPasswordChange);
+app.get("/force-password-change", requireAuth, (req, res) => res.redirect(PASSWORD_CHANGE_PATH));
+app.post("/force-password-change", requireAuth, handleForcedPasswordChange);
 
 // --- Login POST ---
 app.post("/login", async (req, res, next) => {

--- a/school-login/server.test.js
+++ b/school-login/server.test.js
@@ -114,13 +114,13 @@ async function loginAndChangePassword(email, password, newPassword) {
   );
 
   const location = loginResponse.response.headers.get("location");
-  if (location !== "/force-password-change") {
+  if (location !== "/changepw") {
     return { cookies: loginResponse.cookies, redirect: location };
   }
 
-  const forcePage = await fetchWithCookies("/force-password-change", {}, loginResponse.cookies);
+  const forcePage = await fetchWithCookies("/changepw", {}, loginResponse.cookies);
   const forceToken = extractCsrfToken(forcePage.body);
-  assert.ok(forceToken, "CSRF token missing in force-password-change page");
+  assert.ok(forceToken, "CSRF token missing in changepw page");
 
   const changeParams = new URLSearchParams({
     _csrf: forceToken,
@@ -128,7 +128,7 @@ async function loginAndChangePassword(email, password, newPassword) {
   });
 
   const changeResponse = await fetchWithCookies(
-    "/force-password-change",
+    "/changepw",
     {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -356,7 +356,7 @@ test("maintenance mode limits login to admins and kicks existing non-admin sessi
       adminLogin.cookies
     );
     assert.strictEqual(adminResponse.response.status, 302);
-    assert.strictEqual(adminResponse.response.headers.get("location"), "/force-password-change");
+    assert.strictEqual(adminResponse.response.headers.get("location"), "/changepw");
 
     const statelessAdminResponse = await fetchWithCookies("/login", {
       method: "POST",
@@ -649,7 +649,7 @@ test("admin can email a one-time password reset that is consumed on login", { co
   );
 
   assert.strictEqual(oneTimeLogin.response.status, 302);
-  assert.strictEqual(oneTimeLogin.response.headers.get("location"), "/force-password-change");
+  assert.strictEqual(oneTimeLogin.response.headers.get("location"), "/changepw");
 
   const replayPage = await fetchWithCookies("/login");
   const replayToken = extractCsrfToken(replayPage.body);
@@ -669,13 +669,13 @@ test("admin can email a one-time password reset that is consumed on login", { co
   );
   assert.strictEqual(replayLogin.response.status, 401);
 
-  const forcePage = await fetchWithCookies("/force-password-change", {}, oneTimeLogin.cookies);
+  const forcePage = await fetchWithCookies("/changepw", {}, oneTimeLogin.cookies);
   assert.strictEqual(forcePage.response.status, 200);
   const forceToken = extractCsrfToken(forcePage.body);
-  assert.ok(forceToken, "CSRF token missing on force-password-change page");
+  assert.ok(forceToken, "CSRF token missing on changepw page");
 
   const changeResponse = await fetchWithCookies(
-    "/force-password-change",
+    "/changepw",
     {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/school-login/views/admin/edit.ejs
+++ b/school-login/views/admin/edit.ejs
@@ -86,55 +86,86 @@
                 <div>
                   <p class="admin-eyebrow">Passwort</p>
                   <h3>Zugang zurücksetzen</h3>
-                  <p class="admin-muted">Aktueller Passwortstatus: <strong><%= passwordState %></strong></p>
+                  <p class="admin-muted admin-user-edit-password-status">Aktueller Passwortstatus: <strong><%= passwordState %></strong></p>
                 </div>
               </div>
 
-              <div class="admin-user-edit-reset-mail">
-                <div>
-                  <h4>Einmalpasswort per E-Mail</h4>
-                  <p class="admin-muted">Erstellt ein kryptografisch generiertes Einmalpasswort, sendet es an <strong><%= user.email %></strong> und erzwingt nach dem Login einen Passwortwechsel.</p>
-                </div>
-                <form
-                  method="POST"
-                  action="/admin/users/<%= user.id %>/email-reset"
-                  data-confirm-title="Einmalpasswort senden"
-                  data-confirm-message="MÃ¶chtest du ein neues Einmalpasswort an <%= user.email %> senden?"
-                  data-confirm-note="Vorherige offene EinmalpasswÃ¶rter fÃ¼r diesen Nutzer werden ungÃ¼ltig."
-                  data-confirm-action="Senden"
-                >
-                  <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                  <button class="btn btn-primary" type="submit" <%= user.status !== 'active' ? 'disabled' : '' %>>Einmalpasswort senden</button>
-                </form>
+              <div class="admin-user-edit-reset-options">
+                <article class="admin-user-edit-reset-option is-email">
+                  <div>
+                    <h4>Einmalpasswort per E-Mail</h4>
+                  </div>
+                  <form
+                    method="POST"
+                    action="/admin/users/<%= user.id %>/email-reset"
+                    data-confirm-title="Einmalpasswort senden"
+                    data-confirm-message="Möchtest du ein neues Einmalpasswort an <%= user.email %> senden?"
+                    data-confirm-note="Vorherige offene Einmalpasswörter für diesen Nutzer werden ungültig."
+                    data-confirm-action="Senden"
+                  >
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <button class="btn btn-primary" type="submit" <%= user.status !== 'active' ? 'disabled' : '' %>>Einmalpasswort senden</button>
+                  </form>
+                </article>
+
+                <article class="admin-user-edit-reset-option is-custom">
+                  <div>
+                    <h4>Benutzerdefiniertes Passwort festlegen</h4>
+                  </div>
+                  <form class="admin-edit-form admin-stacked-form" method="POST" action="/admin/users/<%= user.id %>/reset">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <input type="hidden" name="returnTo" value="/admin/users/<%= user.id %>/edit">
+                    <label class="admin-field" for="password">
+                      <span>Neues Passwort</span>
+                      <input id="password" name="password" type="password" autocomplete="new-password" required>
+                      <span class="admin-field-hint">Mindestens 10 Zeichen, inkl. Zahl.</span>
+                    </label>
+                    <div class="admin-user-edit-actions">
+                      <button class="btn" type="submit">Benutzerdefiniert setzen</button>
+                    </div>
+                  </form>
+                </article>
+
+                <article class="admin-user-edit-reset-option is-initial">
+                  <div>
+                    <h4>Initial-Kennwort setzen</h4>
+                  </div>
+                  <form
+                    method="POST"
+                    action="/admin/users/<%= user.id %>/reset"
+                    data-confirm-title="Initial-Kennwort setzen"
+                    data-confirm-message="Möchtest du das Initial-Kennwort für <%= user.email %> setzen?"
+                    data-confirm-note="Der Nutzer muss beim nächsten Login ein eigenes Passwort vergeben."
+                    data-confirm-action="Setzen"
+                  >
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <input type="hidden" name="useInitial" value="1">
+                    <input type="hidden" name="returnTo" value="/admin/users/<%= user.id %>/edit">
+                    <button class="btn btn-secondary" type="submit">Initial-Kennwort setzen</button>
+                  </form>
+                </article>
               </div>
 
               <% if (resetRequests.length > 0) { %>
-                <div class="admin-user-edit-reset-history">
-                  <h4>Letzte ZurÃ¼cksetzungsanfragen</h4>
+                <details class="admin-user-edit-reset-history">
+                  <summary>
+                    <span>Letzte Zurücksetzungsanfragen</span>
+                    <span class="admin-user-edit-reset-count"><%= resetRequests.length %></span>
+                  </summary>
+                  <div class="admin-user-edit-reset-history-body">
                   <ul>
                     <% resetRequests.forEach(function(request) { %>
                       <li>
                         <span class="admin-badge <%= request.status === 'active' ? 'admin-badge-success' : 'admin-badge-neutral' %>"><%= request.status_label %></span>
                         <span>Erstellt: <%= request.created_at || '-' %></span>
-                        <span>GÃ¼ltig bis: <%= request.expires_at || '-' %></span>
+                        <span>Gültig bis: <%= request.expires_at || '-' %></span>
                         <span>Von: <%= request.requested_by_email || '-' %></span>
                       </li>
                     <% }) %>
                   </ul>
-                </div>
+                  </div>
+                </details>
               <% } %>
-
-              <form class="admin-edit-form admin-stacked-form" method="POST" action="/admin/users/<%= user.id %>/reset">
-                <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                <label class="admin-field" for="password">
-                  <span>Neues Passwort</span>
-                  <input id="password" name="password" type="password" required>
-                  <span class="admin-field-hint">Das Passwort wird sofort ersetzt. Der Nutzer muss es danach nicht automatisch ändern.</span>
-                </label>
-                <div class="admin-user-edit-actions">
-                  <button class="btn" type="submit">Passwort zurücksetzen</button>
-                </div>
-              </form>
             </section>
 
             <section class="admin-card admin-user-edit-panel admin-user-edit-danger">

--- a/school-login/views/force-password-change.ejs
+++ b/school-login/views/force-password-change.ejs
@@ -1,6 +1,6 @@
 <%
   const page = {
-    title: 'Passwort ändern erforderlich',
+    title: 'Passwort aendern',
     headerTitle: 'Sicherheit',
     styles: ['/css/login.css'],
     scripts: ['/js/app.js'],
@@ -8,35 +8,41 @@
     hideHeader: true,
     hideFooter: true,
     content: function () { %>
-    <div class="login-shell">
-      <div class="login-card">
-        <div class="login-card-header">
-          <p class="login-eyebrow">Passwort aktualisieren</p>
-          <h1>Initial-Kennwort ändern</h1>
+    <div class="changepw-shell">
+      <section class="changepw-card">
+        <div class="login-brand changepw-brand">
+          <img src="/images/nvs-logo.png" alt="Notenverwaltungssystem Logo" class="login-mark">
+          <div>
+            <div class="login-eyebrow">HTL Waidhofen</div>
+            <div class="login-title-inline">Notenverwaltung</div>
+          </div>
         </div>
-        <p class="login-helper">Du bist mit dem Initial-Kennwort angemeldet. Bitte lege jetzt ein neues Passwort fest, um fortzufahren.</p>
-        <% if (typeof error !== 'undefined' && error) { %>
-          <div class="login-error"><%= error %></div>
-        <% } %>
-        <form method="POST" action="/force-password-change" class="login-form">
-          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-          <label for="newPassword">Neues Passwort für <%= email %></label>
-          <input id="newPassword" name="newPassword" type="password" placeholder="Sicheres Passwort" required>
-          <button type="submit" class="login-button">Passwort speichern</button>
-        </form>
-      </div>
 
-      <div class="login-modal is-visible" role="alertdialog" aria-modal="true">
-        <div class="login-modal-content">
-          <h2>Passwortwechsel erforderlich</h2>
-          <p>Um die Anwendung nutzen zu können, muss das Initial-Kennwort sofort geändert werden.</p>
-          <ul>
-            <li>Gib ein neues, sicheres Passwort ein.</li>
-            <li>Nach dem Speichern wirst du automatisch weitergeleitet.</li>
-          </ul>
-          <p class="login-helper">Ohne Änderung ist keine weitere Nutzung möglich.</p>
+        <div class="changepw-header">
+          <p class="login-eyebrow">Sicherheit</p>
+          <h1>Neues Passwort setzen</h1>
+          <p>Dein aktueller Zugang ist nur fuer diesen Schritt freigegeben.</p>
         </div>
-      </div>
+
+        <% if (typeof error !== 'undefined' && error) { %>
+          <div class="changepw-error" role="alert"><%= error %></div>
+        <% } %>
+
+        <form method="POST" action="/changepw" class="changepw-form">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <label for="newPassword">
+            <span>Neues Passwort</span>
+            <small><%= email %></small>
+          </label>
+          <input id="newPassword" name="newPassword" type="password" placeholder="Mindestens 10 Zeichen mit Zahl" autocomplete="new-password" required autofocus>
+          <button type="submit" class="btn-login-submit">Passwort speichern</button>
+        </form>
+
+        <div class="changepw-note">
+          <span class="changepw-note-icon" aria-hidden="true">!</span>
+          <p>Nach dem Speichern wird das Einmalpasswort ungueltig.</p>
+        </div>
+      </section>
     </div>
 <% } }; %>
 <%- include('layout', page) %>


### PR DESCRIPTION
**Changelog**

- Added admin-triggered password reset by email
- Generated secure one-time passwords for users
- One-time passwords are hashed and expire automatically
- Users must change password after one-time password login
- Added `/changepw` password change route
- Improved forced password change page design
- Updated admin user edit password reset section
- Added three reset options:
  - One-time password by email
  - Admin-defined password
  - Initial password reset
- Added collapsible password reset history
- Fixed broken umlauts in admin user edit page
- Improved password status display
- Configured local SMTP/Postfix mail delivery support