### PR TITLE
teamsloginfix

### DIFF
--- a/school-login/.env.example
+++ b/school-login/.env.example
@@ -29,7 +29,7 @@ ONE_TIME_PASSWORD_LENGTH=16
 
 # Microsoft Teams iframe embedding. Enable only for HTTPS deployments.
 TEAMS_EMBED_ENABLED=false
-# Defaults to TEAMS_EMBED_ENABLED. Use /login?teams=1 as Teams tab URL for direct Microsoft login.
+# Defaults to TEAMS_EMBED_ENABLED. Use /login?teams=1 as Teams tab URL for Microsoft popup login.
 # TEAMS_MICROSOFT_LOGIN_ONLY=true
 # Optional additional frame ancestors, separated by commas or spaces.
 # When TEAMS_EMBED_ENABLED=true, Teams and cloud.microsoft ancestors are added automatically.

--- a/school-login/docs/kerberos-sso-vm.md
+++ b/school-login/docs/kerberos-sso-vm.md
@@ -313,7 +313,7 @@ Die URL des Teams-Tabs sollte den Teams-Kontext explizit mitgeben:
 https://nvs.htlwydev.at/login?teams=1
 ```
 
-Dann wird innerhalb von Teams direkt zur Microsoft-Anmeldung weitergeleitet. `https://nvs.htlwydev.at/login` im normalen Browser zeigt weiterhin alle Loginmoeglichkeiten.
+Dann zeigt Teams nur die Microsoft-Anmeldung und oeffnet den eigentlichen Microsoft-Login in einem Popup. Das verhindert, dass `login.microsoftonline.com` im Teams-iframe geladen wird. `https://nvs.htlwydev.at/login` im normalen Browser zeigt weiterhin alle Loginmoeglichkeiten.
 
 Test:
 

--- a/school-login/docs/kerberos/templates/nvs.env.example
+++ b/school-login/docs/kerberos/templates/nvs.env.example
@@ -16,7 +16,7 @@ SSO_EMAIL_DOMAIN=htlwydev.at
 
 # Microsoft Teams iframe embedding. Requires HTTPS.
 TEAMS_EMBED_ENABLED=false
-# Defaults to TEAMS_EMBED_ENABLED. Use /login?teams=1 as Teams tab URL for direct Microsoft login.
+# Defaults to TEAMS_EMBED_ENABLED. Use /login?teams=1 as Teams tab URL for Microsoft popup login.
 # TEAMS_MICROSOFT_LOGIN_ONLY=true
 # Optional additional frame ancestors, separated by commas or spaces.
 # When TEAMS_EMBED_ENABLED=true, Teams and cloud.microsoft ancestors are added automatically.

--- a/school-login/public/css/login.css
+++ b/school-login/public/css/login.css
@@ -241,13 +241,23 @@ body.page-force-password {
 }
 
 .btn-login-microsoft.is-disabled,
-.btn-login-microsoft:disabled {
+.btn-login-microsoft:disabled,
+.btn-login-microsoft.is-loading {
   cursor: not-allowed;
   opacity: 0.7;
   box-shadow: none;
   transform: none;
   color: #64748b;
   background: #f8fafc;
+}
+
+.login-popup-status {
+  min-height: 18px;
+  margin: 8px 0 0;
+  color: #4b5563;
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: center;
 }
 
 .login-advanced {

--- a/school-login/public/js/teams-microsoft-login.js
+++ b/school-login/public/js/teams-microsoft-login.js
@@ -1,0 +1,134 @@
+(function () {
+  const loginButton = document.querySelector("[data-microsoft-popup-login]");
+  if (!loginButton) return;
+
+  const statusElement = document.querySelector("[data-microsoft-popup-status]");
+  const completeUrl = loginButton.dataset.microsoftPopupCompleteUrl;
+  const csrfToken = loginButton.dataset.csrfToken;
+  let teamsReady = false;
+  let completionStarted = false;
+
+  function setStatus(message) {
+    if (statusElement) {
+      statusElement.textContent = message || "";
+    }
+  }
+
+  function parseAuthResult(result) {
+    if (!result) return {};
+    if (typeof result === "object") return result;
+    try {
+      return JSON.parse(result);
+    } catch (error) {
+      return { token: String(result) };
+    }
+  }
+
+  async function completePopupLogin(token) {
+    if (completionStarted) return;
+    completionStarted = true;
+    setStatus("Anmeldung wird abgeschlossen...");
+
+    const response = await fetch(completeUrl, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken
+      },
+      body: JSON.stringify({ token })
+    });
+
+    if (!response.ok) {
+      completionStarted = false;
+      throw new Error("Microsoft-Anmeldung konnte nicht abgeschlossen werden.");
+    }
+
+    const payload = await response.json();
+    window.location.assign(payload.redirect || "/");
+  }
+
+  function handleAuthFailure(message) {
+    completionStarted = false;
+    loginButton.removeAttribute("aria-busy");
+    loginButton.classList.remove("is-loading");
+    setStatus(message || "Microsoft-Anmeldung wurde abgebrochen.");
+  }
+
+  function handleAuthSuccess(result) {
+    const payload = parseAuthResult(result);
+    if (!payload.token) {
+      handleAuthFailure("Microsoft-Anmeldung lieferte keinen Abschluss-Token.");
+      return;
+    }
+    completePopupLogin(payload.token).catch((error) => {
+      handleAuthFailure(error.message);
+    });
+  }
+
+  function openWindowPopup(authUrl) {
+    const popup = window.open(
+      authUrl,
+      "nvsMicrosoftLogin",
+      "popup=yes,width=620,height=720,menubar=no,toolbar=no,location=yes,status=no,scrollbars=yes,resizable=yes"
+    );
+
+    if (!popup) {
+      handleAuthFailure("Popup konnte nicht geoeffnet werden.");
+      window.location.assign(authUrl);
+      return;
+    }
+
+    popup.focus();
+  }
+
+  function authenticateWithTeams(authUrl) {
+    const teams = window.microsoftTeams;
+    if (!teamsReady || !teams?.authentication?.authenticate) {
+      return false;
+    }
+
+    teams.authentication.authenticate({
+      url: authUrl,
+      width: 620,
+      height: 720
+    })
+      .then(handleAuthSuccess)
+      .catch((reason) => {
+        handleAuthFailure(typeof reason === "string" ? reason : "Microsoft-Anmeldung wurde abgebrochen.");
+      });
+    return true;
+  }
+
+  if (window.microsoftTeams?.app?.initialize) {
+    window.microsoftTeams.app.initialize()
+      .then(() => {
+        teamsReady = true;
+      })
+      .catch(() => {
+        teamsReady = false;
+      });
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.origin !== window.location.origin) return;
+    const data = event.data || {};
+    if (data.type === "nvs:microsoft-login-complete") {
+      handleAuthSuccess(data);
+    } else if (data.type === "nvs:microsoft-login-failed") {
+      handleAuthFailure(data.message);
+    }
+  });
+
+  loginButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    const authUrl = new URL(loginButton.getAttribute("href"), window.location.origin).toString();
+    loginButton.setAttribute("aria-busy", "true");
+    loginButton.classList.add("is-loading");
+    setStatus("Microsoft-Anmeldung wird geoeffnet...");
+
+    if (!authenticateWithTeams(authUrl)) {
+      openWindowPopup(authUrl);
+    }
+  });
+})();

--- a/school-login/server.js
+++ b/school-login/server.js
@@ -99,7 +99,9 @@ const LOGIN_RATE_WINDOW_MS = Number(process.env.LOGIN_RATE_LIMIT_WINDOW_MS) || 1
 const LOGIN_RATE_MAX = Number(process.env.LOGIN_RATE_LIMIT_MAX) || 5;
 const MAINTENANCE_LOGIN_TOKEN_TTL_MS = 10 * 60 * 1000;
 const PASSWORD_CHANGE_PATH = "/changepw";
+const MICROSOFT_POPUP_LOGIN_TOKEN_TTL_MS = 2 * 60 * 1000;
 const loginAttempts = new Map();
+const microsoftPopupLoginCompletions = new Map();
 const teamsEmbedEnabled = parseOptionalBoolean(process.env.TEAMS_EMBED_ENABLED) ?? false;
 const teamsMicrosoftLoginOnly =
   parseOptionalBoolean(process.env.TEAMS_MICROSOFT_LOGIN_ONLY) ?? teamsEmbedEnabled;
@@ -166,12 +168,33 @@ function resetLoginAttempts(key) {
   loginAttempts.delete(key);
 }
 
+function queryValueMatchesTruthy(value) {
+  if (value == null) return false;
+  const values = Array.isArray(value) ? value : [value];
+  return values.some((entry) => {
+    const normalized = String(entry || "").trim().toLowerCase();
+    return ["1", "true", "yes", "on"].includes(normalized);
+  });
+}
+
 function queryValueMatchesTeams(value) {
   if (value == null) return false;
   const values = Array.isArray(value) ? value : [value];
   return values.some((entry) => {
     const normalized = String(entry || "").trim().toLowerCase();
-    return ["1", "true", "yes", "on", "teams", "msteams", "microsoftteams"].includes(normalized);
+    return (
+      queryValueMatchesTruthy(normalized) ||
+      ["teams", "msteams", "microsoftteams"].includes(normalized)
+    );
+  });
+}
+
+function queryValueMatchesPopup(value) {
+  if (value == null) return false;
+  const values = Array.isArray(value) ? value : [value];
+  return values.some((entry) => {
+    const normalized = String(entry || "").trim().toLowerCase();
+    return queryValueMatchesTruthy(normalized) || normalized === "popup";
   });
 }
 
@@ -213,6 +236,18 @@ function isTeamsLoginContext(req) {
 
 function shouldUseMicrosoftOnlyLogin(req) {
   return teamsMicrosoftLoginOnly && isTeamsLoginContext(req);
+}
+
+function shouldUseMicrosoftPopupLogin(req) {
+  return shouldUseMicrosoftOnlyLogin(req) && !isMaintenanceMode(req);
+}
+
+function getMicrosoftLoginUrl(req) {
+  return shouldUseMicrosoftPopupLogin(req) ? "/auth/microsoft?popup=1" : "/auth/microsoft";
+}
+
+function isMicrosoftPopupLoginRequest(req) {
+  return queryValueMatchesPopup(req.query?.popup);
 }
 
 function getRequestRuntimeSettings(req) {
@@ -279,13 +314,6 @@ function verifyMaintenanceLoginToken(token) {
 
 function isMaintenanceLoginPost(req) {
   return req.method === "POST" && req.path === "/login" && isMaintenanceMode(req);
-}
-
-function saveSessionAndRedirect(req, res, next, target) {
-  req.session.save((saveErr) => {
-    if (saveErr) return next(saveErr);
-    return res.redirect(target);
-  });
 }
 
 app.use(express.urlencoded({ extended: true }));
@@ -362,6 +390,8 @@ function renderLogin(res, req, options = {}) {
     email,
     microsoftAuthEnabled: isMicrosoftLoginAvailable(req),
     microsoftOnlyLogin: shouldUseMicrosoftOnlyLogin(req) && !isMaintenanceMode(req),
+    microsoftPopupLogin: shouldUseMicrosoftPopupLogin(req),
+    microsoftLoginUrl: getMicrosoftLoginUrl(req),
     maintenanceMode: isMaintenanceMode(req),
     maintenanceLoginToken: isMaintenanceMode(req) ? createMaintenanceLoginToken() : ""
   });
@@ -470,6 +500,168 @@ function renderMicrosoftAuthError(res, req, message, status = 401, email = "") {
     errorMessage: message,
     email
   });
+}
+
+function pruneExpiredMicrosoftPopupCompletions(now = Date.now()) {
+  for (const [token, completion] of microsoftPopupLoginCompletions.entries()) {
+    if (!completion?.expiresAt || completion.expiresAt <= now) {
+      microsoftPopupLoginCompletions.delete(token);
+    }
+  }
+}
+
+function createMicrosoftPopupCompletion(user) {
+  pruneExpiredMicrosoftPopupCompletions();
+  const token = crypto.randomBytes(32).toString("base64url");
+  microsoftPopupLoginCompletions.set(token, {
+    user,
+    expiresAt: Date.now() + MICROSOFT_POPUP_LOGIN_TOKEN_TTL_MS
+  });
+  return token;
+}
+
+function consumeMicrosoftPopupCompletion(token) {
+  pruneExpiredMicrosoftPopupCompletions();
+  const normalizedToken = String(token || "");
+  const completion = microsoftPopupLoginCompletions.get(normalizedToken);
+  if (!completion) return null;
+  microsoftPopupLoginCompletions.delete(normalizedToken);
+  return completion;
+}
+
+function escapeHtml(value) {
+  return String(value || "").replace(/[&<>"']/g, (character) => {
+    const entities = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;"
+    };
+    return entities[character] || character;
+  });
+}
+
+function safeJsonForScript(value) {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+function renderMicrosoftPopupResult(res, options = {}) {
+  const success = Boolean(options.success);
+  const message =
+    options.message ||
+    (success
+      ? "Die Microsoft-Anmeldung wurde abgeschlossen."
+      : "Die Microsoft-Anmeldung konnte nicht abgeschlossen werden.");
+  const payload = {
+    success,
+    token: options.token || "",
+    message
+  };
+
+  return res.status(success ? 200 : 401).type("html").send(`<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Microsoft Anmeldung | NVS</title>
+  <style>
+    :root { color-scheme: light; }
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+      background: #f8fafc;
+      color: #111827;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      width: min(100% - 32px, 420px);
+      padding: 24px;
+      border: 1px solid #dbe3f0;
+      border-radius: 8px;
+      background: #ffffff;
+      box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+      text-align: center;
+    }
+    h1 { margin: 0 0 8px; font-size: 21px; line-height: 1.2; }
+    p { margin: 0 0 18px; color: #4b5563; line-height: 1.45; }
+    button {
+      min-height: 42px;
+      padding: 10px 14px;
+      border: 1px solid #003da5;
+      border-radius: 8px;
+      background: #003da5;
+      color: #ffffff;
+      font-weight: 700;
+      cursor: pointer;
+    }
+  </style>
+  <script src="https://res.cdn.office.net/teams-js/2.53.0/js/MicrosoftTeams.min.js"></script>
+</head>
+<body>
+  <main>
+    <h1>${success ? "Anmeldung abgeschlossen" : "Anmeldung fehlgeschlagen"}</h1>
+    <p>${escapeHtml(message)}</p>
+    <button type="button" id="close-button">Fenster schliessen</button>
+  </main>
+  <script>
+    (function () {
+      var result = ${safeJsonForScript(payload)};
+      var message = result.success
+        ? { type: "nvs:microsoft-login-complete", token: result.token }
+        : { type: "nvs:microsoft-login-failed", message: result.message };
+
+      function notifyParentWindow() {
+        if (window.opener && !window.opener.closed) {
+          window.opener.postMessage(message, window.location.origin);
+          return true;
+        }
+        return false;
+      }
+
+      function notifyTeamsHost() {
+        var teams = window.microsoftTeams;
+        if (!teams || !teams.app || !teams.authentication) {
+          return Promise.resolve(false);
+        }
+        return teams.app.initialize()
+          .then(function () {
+            if (result.success) {
+              teams.authentication.notifySuccess(JSON.stringify({ token: result.token }));
+            } else {
+              teams.authentication.notifyFailure(result.message);
+            }
+            return true;
+          })
+          .catch(function () {
+            return false;
+          });
+      }
+
+      function closeSoon() {
+        window.setTimeout(function () {
+          window.close();
+        }, 450);
+      }
+
+      notifyTeamsHost().then(function (usedTeamsHost) {
+        if (!usedTeamsHost) {
+          notifyParentWindow();
+        }
+        if (result.success) {
+          closeSoon();
+        }
+      });
+
+      document.getElementById("close-button").addEventListener("click", function () {
+        window.close();
+      });
+    })();
+  </script>
+</body>
+</html>`);
 }
 
 // --- Session ---
@@ -788,13 +980,14 @@ app.get("/login", (req, res, next) => {
         503
       );
     }
-    return saveSessionAndRedirect(req, res, next, "/auth/microsoft");
+    return renderLogin(res, req);
   }
   renderLogin(res, req);
 });
 
 app.get("/auth/microsoft", (req, res, next) => {
   rememberTeamsLoginContext(req);
+  const popupLogin = isMicrosoftPopupLoginRequest(req);
   if (req.session.user) {
     return res.redirect("/");
   }
@@ -820,7 +1013,8 @@ app.get("/auth/microsoft", (req, res, next) => {
   req.session.microsoftAuth = {
     state: authorizationRequest.state,
     nonce: authorizationRequest.nonce,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    popup: popupLogin
   };
 
   req.session.save((saveErr) => {
@@ -832,6 +1026,7 @@ app.get("/auth/microsoft", (req, res, next) => {
 app.get("/auth/microsoft/callback", async (req, res, next) => {
   const authState = req.session.microsoftAuth;
   const isLinkMode = authState?.mode === "link";
+  const isPopupLogin = Boolean(authState?.popup && !isLinkMode);
 
   if (req.session.user && !isLinkMode) {
     return res.redirect("/");
@@ -852,6 +1047,12 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
     if (isLinkMode) {
       return res.redirect("/account/microsoft-link?error=microsoft-cancelled");
     }
+    if (isPopupLogin) {
+      return renderMicrosoftPopupResult(res, {
+        success: false,
+        message: "Die Microsoft-Anmeldung wurde abgebrochen oder verweigert."
+      });
+    }
     return renderMicrosoftAuthError(
       res,
       req,
@@ -863,6 +1064,12 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
   if (!code || !state || !authState || authState.state !== state || isExpired) {
     if (isLinkMode) {
       return res.redirect("/account/microsoft-link?error=microsoft-state");
+    }
+    if (isPopupLogin) {
+      return renderMicrosoftPopupResult(res, {
+        success: false,
+        message: "Die Microsoft-Anmeldung konnte nicht bestaetigt werden."
+      });
     }
     return renderMicrosoftAuthError(
       res,
@@ -878,6 +1085,12 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
     if (!isAllowedMicrosoftDomain(email)) {
       if (isLinkMode) {
         return res.redirect("/account/microsoft-link?error=domain-blocked");
+      }
+      if (isPopupLogin) {
+        return renderMicrosoftPopupResult(res, {
+          success: false,
+          message: "Dieses Microsoft-Konto ist fuer die Schulanmeldung nicht freigegeben."
+        });
       }
       return renderMicrosoftAuthError(
         res,
@@ -929,6 +1142,12 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
 
     const user = await findUserByMicrosoftAccount(profile);
     if (!user || user.status !== "active") {
+      if (isPopupLogin) {
+        return renderMicrosoftPopupResult(res, {
+          success: false,
+          message: "Dieses Microsoft-Konto ist noch mit keinem NVS-Konto verknuepft."
+        });
+      }
       return renderMicrosoftAuthError(
         res,
         req,
@@ -936,6 +1155,14 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
         401,
         email
       );
+    }
+
+    if (isPopupLogin) {
+      const completionToken = createMicrosoftPopupCompletion(user);
+      return renderMicrosoftPopupResult(res, {
+        success: true,
+        token: completionToken
+      });
     }
 
     const redirectTarget = await completeLogin(req, user);
@@ -950,12 +1177,39 @@ app.get("/auth/microsoft/callback", async (req, res, next) => {
       if (isLinkMode) {
         return res.redirect("/account/microsoft-link?error=microsoft-failed");
       }
+      if (isPopupLogin) {
+        return renderMicrosoftPopupResult(res, {
+          success: false,
+          message: "Microsoft-Anmeldung fehlgeschlagen. Bitte spaeter erneut versuchen."
+        });
+      }
       return renderMicrosoftAuthError(
         res,
         req,
         "Microsoft-Anmeldung fehlgeschlagen. Bitte spaeter erneut versuchen."
       );
     }
+    return next(err);
+  }
+});
+
+app.post("/auth/microsoft/popup/complete", async (req, res, next) => {
+  if (!isMicrosoftLoginAvailable(req)) {
+    return res.status(503).json({ error: "microsoft_login_unavailable" });
+  }
+
+  const completion = consumeMicrosoftPopupCompletion(req.body?.token);
+  if (!completion?.user) {
+    return res.status(400).json({ error: "invalid_or_expired_token" });
+  }
+  if (completion.user.status !== "active") {
+    return res.status(401).json({ error: "inactive_account" });
+  }
+
+  try {
+    const redirectTarget = await completeLogin(req, completion.user);
+    return res.json({ redirect: redirectTarget });
+  } catch (err) {
     return next(err);
   }
 });
@@ -1024,7 +1278,7 @@ app.post("/login", async (req, res, next) => {
         503
       );
     }
-    return res.redirect("/auth/microsoft");
+    return renderLogin(res, req);
   }
 
   const { email, password } = req.body || {};

--- a/school-login/server.test.js
+++ b/school-login/server.test.js
@@ -43,6 +43,17 @@ function extractHiddenInput(html, name) {
   return match ? match[1] : null;
 }
 
+function extractDataAttribute(html, name) {
+  const escapedName = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = html.match(new RegExp(`${escapedName}="([^"]*)"`, "i"));
+  return match ? match[1] : null;
+}
+
+function extractMicrosoftPopupToken(html) {
+  const match = html.match(/"token":"([^"]+)"/);
+  return match ? match[1] : null;
+}
+
 function extractStudentInitialData(html) {
   const match = html.match(
     /<script type="application\/json" id="student-initial-data">([\s\S]*?)<\/script>/
@@ -262,13 +273,15 @@ test("GET /login renders the Microsoft login option when configured", async () =
   assert.match(body, /Mit Microsoft anmelden/);
 });
 
-test("Teams login entry redirects directly to Microsoft auth", async () => {
-  const loginStart = await fetchWithCookies("/login?teams=1", { redirect: "manual" });
-  assert.strictEqual(loginStart.response.status, 302);
-  assert.strictEqual(loginStart.response.headers.get("location"), "/auth/microsoft");
+test("Teams login entry renders a Microsoft popup launcher", async () => {
+  const loginStart = await fetchWithCookies("/login?teams=1");
+  assert.strictEqual(loginStart.response.status, 200);
+  assert.match(loginStart.body, /data-microsoft-popup-login/);
+  assert.match(loginStart.body, /href="\/auth\/microsoft\?popup=1"/);
+  assert.doesNotMatch(loginStart.body, /name="password"/);
 
   const authStart = await fetchWithCookies(
-    "/auth/microsoft",
+    "/auth/microsoft?popup=1",
     { redirect: "manual" },
     loginStart.cookies
   );
@@ -278,6 +291,116 @@ test("Teams login entry redirects directly to Microsoft auth", async () => {
     authLocation.startsWith("https://login.microsoftonline.com/"),
     "Teams login should continue with Microsoft authorization"
   );
+});
+
+test("Teams Microsoft popup handoff completes login in the parent session", { concurrency: false }, async () => {
+  const microsoftTeamsEmail = "microsoft-teams-admin@test.local";
+  const insertResult = await dbRun(
+    "INSERT INTO users (email, password_hash, role, status, must_change_password) VALUES (?,?,?,?,?)",
+    [
+      microsoftTeamsEmail,
+      hashPassword("UnusedPass123!"),
+      "admin",
+      "active",
+      0
+    ]
+  );
+  await dbRun(
+    "UPDATE users SET microsoft_oid = ?, microsoft_tenant_id = ?, microsoft_email = ?, microsoft_connected_at = current_timestamp WHERE id = ?",
+    ["oid-teams-1", "tenant-teams-1", microsoftTeamsEmail, insertResult.lastID]
+  );
+
+  const originalFetch = global.fetch;
+  global.fetch = async (input, init) => {
+    const requestUrl = typeof input === "string"
+      ? input
+      : String(input?.url || input);
+
+    if (
+      requestUrl.startsWith("https://login.microsoftonline.com/")
+      && requestUrl.endsWith("/oauth2/v2.0/token")
+    ) {
+      return new Response(
+        JSON.stringify({
+          access_token: "microsoft-teams-access-token",
+          id_token: buildMockIdToken({
+            email: microsoftTeamsEmail,
+            preferred_username: microsoftTeamsEmail,
+            oid: "oid-teams-1",
+            tid: "tenant-teams-1"
+          })
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+    }
+
+    if (requestUrl === "https://graph.microsoft.com/oidc/userinfo") {
+      return new Response(
+        JSON.stringify({
+          email: microsoftTeamsEmail,
+          preferred_username: microsoftTeamsEmail,
+          name: "Teams Admin",
+          sub: "oid-teams-1"
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+    }
+
+    return originalFetch(input, init);
+  };
+
+  try {
+    const parentLoginPage = await fetchWithCookies("/login?teams=1");
+    assert.strictEqual(parentLoginPage.response.status, 200);
+    const parentCsrfToken = extractDataAttribute(parentLoginPage.body, "data-csrf-token");
+    assert.ok(parentCsrfToken, "CSRF token missing on Teams login launcher");
+
+    const popupAuthStart = await fetchWithCookies("/auth/microsoft?popup=1", { redirect: "manual" });
+    assert.strictEqual(popupAuthStart.response.status, 302);
+    const popupAuthLocation = popupAuthStart.response.headers.get("location");
+    assert.ok(popupAuthLocation, "Microsoft popup authorization redirect missing");
+    const popupAuthUrl = new URL(popupAuthLocation);
+    const popupAuthState = popupAuthUrl.searchParams.get("state");
+    assert.ok(popupAuthState, "Microsoft popup auth state missing");
+
+    const popupCallback = await fetchWithCookies(
+      `/auth/microsoft/callback?code=test-code&state=${encodeURIComponent(popupAuthState)}`,
+      { redirect: "manual" },
+      popupAuthStart.cookies
+    );
+    assert.strictEqual(popupCallback.response.status, 200);
+    assert.match(popupCallback.body, /Anmeldung abgeschlossen/);
+    const completionToken = extractMicrosoftPopupToken(popupCallback.body);
+    assert.ok(completionToken, "Popup completion token missing");
+
+    const completionResponse = await fetchWithCookies(
+      "/auth/microsoft/popup/complete",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": parentCsrfToken
+        },
+        body: JSON.stringify({ token: completionToken }),
+        redirect: "manual"
+      },
+      parentLoginPage.cookies
+    );
+    assert.strictEqual(completionResponse.response.status, 200);
+    assert.deepStrictEqual(JSON.parse(completionResponse.body), { redirect: "/admin" });
+
+    const adminPage = await fetchWithCookies("/admin", {}, completionResponse.cookies);
+    assert.strictEqual(adminPage.response.status, 200);
+    assert.match(adminPage.body, /microsoft-teams-admin@test\.local/);
+  } finally {
+    global.fetch = originalFetch;
+  }
 });
 
 test("runtime settings can disable Microsoft login without restart", async () => {

--- a/school-login/views/login.ejs
+++ b/school-login/views/login.ejs
@@ -5,13 +5,21 @@
   const _email = typeof email !== "undefined" ? email : "";
   const _microsoftAuthEnabled = Boolean(microsoftAuthEnabled);
   const _microsoftOnlyLogin = Boolean(microsoftOnlyLogin);
+  const _microsoftPopupLogin = Boolean(microsoftPopupLogin);
+  const _microsoftLoginUrl = typeof microsoftLoginUrl !== "undefined" ? microsoftLoginUrl : "/auth/microsoft";
   const _maintenanceMode = Boolean(maintenanceMode);
   const _maintenanceLoginToken = typeof maintenanceLoginToken !== "undefined" ? maintenanceLoginToken : "";
+
+  const pageScripts = ["/js/app.js"];
+  if (_microsoftPopupLogin) {
+    pageScripts.push("https://res.cdn.office.net/teams-js/2.53.0/js/MicrosoftTeams.min.js");
+    pageScripts.push("/js/teams-microsoft-login.js");
+  }
 
   const page = {
     title: "Login | Notenverwaltungssystem",
     styles: ["/css/login.css"],
-    scripts: ["/js/app.js"],
+    scripts: pageScripts,
     bodyClass: "page-login",
     hideHeader: true,
     hideFooter: true,
@@ -23,6 +31,8 @@
         _email,
         _microsoftAuthEnabled,
         _microsoftOnlyLogin,
+        _microsoftPopupLogin,
+        _microsoftLoginUrl,
         _maintenanceMode,
         _maintenanceLoginToken
       });

--- a/school-login/views/partials/login-card.ejs
+++ b/school-login/views/partials/login-card.ejs
@@ -59,7 +59,18 @@
   <% } %>
 
   <% if (!_maintenanceMode && _microsoftAuthEnabled) { %>
-    <a class="btn-login-microsoft" href="/auth/microsoft">Mit Microsoft anmelden</a>
+    <a
+      class="btn-login-microsoft<%= _microsoftPopupLogin ? ' is-popup-login' : '' %>"
+      href="<%= _microsoftLoginUrl %>"
+      <% if (_microsoftPopupLogin) { %>
+        data-microsoft-popup-login
+        data-microsoft-popup-complete-url="/auth/microsoft/popup/complete"
+        data-csrf-token="<%= _csrfToken %>"
+      <% } %>
+    >Mit Microsoft anmelden</a>
+    <% if (_microsoftPopupLogin) { %>
+      <p class="login-popup-status" data-microsoft-popup-status role="status" aria-live="polite"></p>
+    <% } %>
   <% } %>
 
   <% if (!_maintenanceMode) { %>


### PR DESCRIPTION
- Replaced the Teams direct Microsoft redirect with a popup-based login flow.
- Added a Teams login script using TeamsJS, with `window.open` fallback.
- Added a short-lived server-side popup completion token to transfer login success back to the embedded Teams page.
- Added `/auth/microsoft/popup/complete` to create the real app session in the Teams iframe.